### PR TITLE
Attempt triggering a gov state transition after updating the escrow state

### DIFF
--- a/contracts/Escrow.sol
+++ b/contracts/Escrow.sol
@@ -2,6 +2,7 @@
 pragma solidity 0.8.23;
 
 import {Configuration} from "./Configuration.sol";
+import {GovernanceState} from "./GovernanceState.sol";
 
 
 interface IERC20 {
@@ -82,35 +83,54 @@ contract Escrow {
     /// Staker interface
     ///
 
+    // FIXME remove after locking/unlocking is implemented
+    function mock__lockStEth(uint256 amount) external {
+        _totalStEthLocked += amount;
+        _activateNextGovernanceState();
+    }
+
+    // FIXME remove after locking/unlocking is implemented
+    function mock__unlockStEth(uint256 amount) external {
+        _totalStEthLocked -= amount;
+        _activateNextGovernanceState();
+    }
+
     function lockStEth() external {
         // TODO: transferFrom caller, record caller's new total amount
         // TODO: only allow in Signalling and RageQuitAccumulation
+        _activateNextGovernanceState();
     }
 
     function lockWstEth() external {
         // TODO: transferFrom caller, record caller's new total amount
         // TODO: only allow in Signalling and RageQuitAccumulation
+        _activateNextGovernanceState();
     }
 
     function initiateStEthWithdrawal() external {
         // TODO: convert locked stETH to locked withdrawal NFTs
         // TODO: only allow in Signalling
+        _activateNextGovernanceState();
     }
 
     function unlockStEth() external {
         // TODO: only allow in Signalling
+        _activateNextGovernanceState();
     }
 
     function unlockWstEth() external {
         // TODO: only allow in Signalling
+        _activateNextGovernanceState();
     }
 
     function lockWithdrawalNFT() external {
         // TODO: only allow in Signalling and RageQuitAccumulation
+        _activateNextGovernanceState();
     }
 
     function unlockWithdrawalNFT() external {
         // TODO: only allow in Signalling
+        _activateNextGovernanceState();
     }
 
     function claimETH() external {
@@ -242,5 +262,9 @@ contract Escrow {
     function claimNextETHBatch(uint256[] calldata requestIds, uint256[] calldata hints) external {
         // TODO: check that all requests are claimed
         IWithdrawalQueue(WITHDRAWAL_QUEUE).claimWithdrawalsTo(requestIds, hints, address(this));
+    }
+
+    function _activateNextGovernanceState() internal {
+        GovernanceState(_govState).activateNextState();
     }
 }


### PR DESCRIPTION
Calls `GovernanceState.activateNextState()` each time (w)stETH or a withdrawal NFT is locked into or unlocked from the signalling escrow.

Improves correctness of the DG state transitions during the escalation/de-escalation phase at the cost of more expensive participation for stakers (due to higher gas spending).

### Reasoning

Each call to the `activateNextState` benefits someone. It's ok to require calling it when it benefits some advanced party. However, in the case of locking/unlocking stETH, it's the stakers who benefit from calling `activateNextState` in a timely manner, and we shouldn't expect stakers to behave in an advanced manner or rely on some bot being active for time-sensitive calls. If `activateNextState` is not called in a timely manner, a proposer still won't be able to execute the proposal being opposed while stakers have their stETH locked in the escrow, but the veto deactivation and cooldown states could be skipped when they de-escalate by unlocking stETH, resulting in the proposal becoming executable earlier than designed.