### PR TITLE
Timelocked Agent: fixes and tests

### DIFF
--- a/contracts/Agent.sol
+++ b/contracts/Agent.sol
@@ -10,6 +10,12 @@ contract Agent {
     error Unauthorized();
     error EmergencyMultisigExpired();
 
+    // copied from TimelockCallSet
+    error TimelockNotExpired();
+    error CallCancelled();
+    error CallIdNotCancelled(uint256 id);
+    error IdNotFound();
+
     event GovernanceSet(address indexed governance);
     event TimelockDurationSet(uint256 duration);
     event EmergencyMultisigSet(address indexed emergencyMultisig);
@@ -99,6 +105,10 @@ contract Agent {
 
     function getScheduledCall(uint256 callId) external view returns (TimelockCallSet.Call memory) {
         return _timelockCallSet.get(callId);
+    }
+
+    function unscheduleCancelledCalls(uint256[] calldata callIds) external {
+        _timelockCallSet.removeCancelledCalls(callIds);
     }
 
     function _call(address target, bytes memory data) internal {

--- a/contracts/DualGovernance.sol
+++ b/contracts/DualGovernance.sol
@@ -183,8 +183,7 @@ contract DualGovernance {
         });
         proposal.isExecuted = true;
         _saveProposal(proposalKey, proposal);
-        (address target, bytes memory execData) = votingSystem.getProposalExecData(proposalId, data);
-        AGENT.forwardCall(target, execData);
+        votingSystem.executeProposal(proposalId, data);
         assert(!_propExecution.isForwarding);
         _propExecution.isExecuting = false;
     }

--- a/contracts/voting-systems/AragonVotingSystem.sol
+++ b/contracts/voting-systems/AragonVotingSystem.sol
@@ -43,13 +43,8 @@ contract AragonVotingSystem is IVotingSystem {
         return true;
     }
 
-    function getProposalExecData(uint256 id, bytes calldata /* data */)
-        external
-        view
-        returns (address target, bytes memory execData)
-    {
-        target = VOTING;
-        execData = abi.encodeWithSelector(IAragonVoting.executeVote.selector, id);
+    function executeProposal(uint256 id, bytes calldata /* data */) external {
+        IAragonVoting(VOTING).executeVote(id);
     }
 
     function isValidExecutionForwarder(address addr) external view returns (bool) {

--- a/contracts/voting-systems/IVotingSystem.sol
+++ b/contracts/voting-systems/IVotingSystem.sol
@@ -1,7 +1,16 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.23;
 
-
+/**
+ * Voting system adapter.
+ *
+ * The adapter should not be assigned any permissions over the protocol. If a privileged execution
+ * is needed, the adapter should use DualGovernance.forwardCall to request the call from the Agent.
+ *
+ * The only exception is the permission to submit a proposal to the upstream voting system. If this
+ * permission is assigned to an adapter, the adapter should check that the original submitter is
+ * allowed to submit the proposal.
+ */
 interface IVotingSystem {
     function submitProposal(bytes calldata data, address submitter) external returns (uint256 id, uint256 decidedAt);
     function executeProposal(uint256 id, bytes calldata data) external;

--- a/contracts/voting-systems/IVotingSystem.sol
+++ b/contracts/voting-systems/IVotingSystem.sol
@@ -4,14 +4,6 @@ pragma solidity 0.8.23;
 
 interface IVotingSystem {
     function submitProposal(bytes calldata data, address submitter) external returns (uint256 id, uint256 decidedAt);
-
-    function getProposalExecData(
-        uint256 id,
-        bytes calldata data
-    ) external view returns (
-        address target,
-        bytes memory execData
-    );
-
+    function executeProposal(uint256 id, bytes calldata data) external;
     function isValidExecutionForwarder(address addr) external view returns (bool);
 }

--- a/test/scenario/agent-timelock.t.sol
+++ b/test/scenario/agent-timelock.t.sol
@@ -1,0 +1,166 @@
+pragma solidity 0.8.23;
+
+import {Agent, TimelockCallSet} from "contracts/Agent.sol";
+import {DualGovernance} from "contracts/DualGovernance.sol";
+
+import "../utils/mainnet-addresses.sol";
+import "../utils/interfaces.sol";
+import "../utils/utils.sol";
+
+import {DualGovernanceSetup} from "./setup.sol";
+
+
+contract AgentTimelockTest is DualGovernanceSetup {
+    uint256 internal constant AGENT_TIMELOCK_DURATION = 1 days;
+    uint256 internal constant EMERGENCY_MULTISIG_ACTIVE_FOR = 90 days;
+
+    Agent internal agent;
+    DualGovernance internal dualGov;
+
+    address internal ldoWhale;
+    address emergencyMultisig;
+
+    function setUp() external {
+        Utils.selectFork();
+        Utils.removeLidoStakingLimit();
+
+        ldoWhale = makeAddr("ldo_whale");
+        Utils.setupLdoWhale(ldoWhale);
+
+        emergencyMultisig = makeAddr("emergency_multisig");
+
+        DualGovernanceSetup.Deployed memory deployed = deployDG(
+            DAO_AGENT,
+            DAO_VOTING,
+            LDO_TOKEN,
+            ST_ETH,
+            WST_ETH,
+            WITHDRAWAL_QUEUE,
+            AGENT_TIMELOCK_DURATION,
+            emergencyMultisig,
+            EMERGENCY_MULTISIG_ACTIVE_FOR
+        );
+
+        agent = deployed.agent;
+        dualGov = deployed.dualGov;
+    }
+
+    function test_agent_timelock_happy_path() external {
+        Target target = new Target();
+
+        bytes memory targetCalldata = abi.encodeCall(target.doSmth, (42));
+        bytes memory forwardCalldata = abi.encodeCall(dualGov.forwardCall, (address(target), targetCalldata));
+        bytes memory script = Utils.encodeEvmCallScript(address(dualGov), forwardCalldata);
+
+        uint256 voteId = dualGov.submitProposal(ARAGON_VOTING_SYSTEM_ID, script);
+        Utils.supportVoteAndWaitTillDecided(voteId, ldoWhale);
+
+        // from the Aragon's POV, the proposal is executable
+        assertEq(IAragonVoting(DAO_VOTING).canExecute(voteId), true);
+
+        // however, proposals containing DG-related calls cannot be executed directly
+        vm.expectRevert(DualGovernance.CannotCallOutsideExecution.selector);
+        IAragonVoting(DAO_VOTING).executeVote(voteId);
+
+        // min execution timelock enforced by DG hasn't elapsed yet
+        vm.expectRevert(DualGovernance.ProposalIsNotExecutable.selector);
+        dualGov.executeProposal(ARAGON_VOTING_SYSTEM_ID, voteId, new bytes(0));
+
+        // wait till the DG-enforced timelock elapses
+        vm.warp(block.timestamp + dualGov.CONFIG().minProposalExecutionTimelock());
+
+        // no scheduled calls yet
+        assertEq(agent.getScheduledCallIds().length, 0);
+
+        // no calls to target yet
+        // cannot use forge's expectCall here due to negative assertions' limitations, see issue #5655 in foundry
+        target.expectNoCalls();
+
+        // executing the proposal schedules one call from the Agent
+        dualGov.executeProposal(ARAGON_VOTING_SYSTEM_ID, voteId, new bytes(0));
+
+        uint256[] memory scheduledCallIds = agent.getScheduledCallIds();
+        assertEq(scheduledCallIds.length, 1);
+
+        TimelockCallSet.Call memory call = agent.getScheduledCall(scheduledCallIds[0]);
+        assertEq(call.target, address(target));
+        assertEq(call.data, targetCalldata);
+
+        // the call isn't executable yet
+        assertEq(agent.getExecutableCallIds().length, 0);
+
+        // wait till the Agent-enforced timelock elapses
+        vm.warp(block.timestamp + AGENT_TIMELOCK_DURATION + 1);
+
+        // the call became executable
+        assertEq(agent.getExecutableCallIds(), scheduledCallIds);
+
+        // executing the call invokes the target
+        vm.expectCall(address(target), targetCalldata);
+        target.expectCalledBy(address(agent));
+        agent.executeScheduledCall(scheduledCallIds[0]);
+
+        // no scheduled calls are left
+        assertEq(agent.getScheduledCallIds().length, 0);
+        assertEq(agent.getExecutableCallIds().length, 0);
+    }
+
+    function test_initial_agent_governance_value() external {
+        assertEq(agent.getGovernance(), address(dualGov));
+    }
+
+    function test_agent_timelock_emergency_dg_deactivation() external {
+        Target target = new Target();
+
+        bytes memory targetCalldata = abi.encodeCall(target.doSmth, (42));
+        bytes memory forwardCalldata = abi.encodeCall(dualGov.forwardCall, (address(target), targetCalldata));
+        bytes memory script = Utils.encodeEvmCallScript(address(dualGov), forwardCalldata);
+
+        uint256 voteId = dualGov.submitProposal(ARAGON_VOTING_SYSTEM_ID, script);
+        Utils.supportVoteAndWaitTillDecided(voteId, ldoWhale);
+
+        // wait till the DG-enforced timelock elapses
+        vm.warp(block.timestamp + dualGov.CONFIG().minProposalExecutionTimelock());
+
+        // target won't be called in this test
+        target.expectNoCalls();
+
+        // executing the proposal schedules one call from the Agent
+        dualGov.executeProposal(ARAGON_VOTING_SYSTEM_ID, voteId, new bytes(0));
+
+        uint256[] memory scheduledCallIds = agent.getScheduledCallIds();
+        assertEq(scheduledCallIds.length, 1);
+
+        TimelockCallSet.Call memory call = agent.getScheduledCall(scheduledCallIds[0]);
+        assertEq(call.target, address(target));
+        assertEq(call.data, targetCalldata);
+
+        // some time passes (but less than the Agent-enforced timelock)
+        vm.warp(block.timestamp + AGENT_TIMELOCK_DURATION / 2);
+
+        // the call is not executable yet
+        assertEq(agent.getExecutableCallIds().length, 0);
+
+        // emergency disabling the dual governance system while the multisig is active
+        vm.prank(emergencyMultisig);
+        agent.emergencyResetGovernanceToDAO();
+        assertEq(agent.getGovernance(), DAO_AGENT);
+
+        // waiting till the initial timelock of the scheduled call passes
+        vm.warp(block.timestamp + AGENT_TIMELOCK_DURATION / 2 + 1);
+
+        // the call is still scheduled
+        assertEq(agent.getScheduledCallIds(), scheduledCallIds);
+        call = agent.getScheduledCall(scheduledCallIds[0]);
+        assertLt(call.lockedTill, block.timestamp);
+
+        // but cannot be executed
+        assertEq(agent.getExecutableCallIds().length, 0);
+        vm.expectRevert(Agent.CallCancelled.selector);
+        agent.executeScheduledCall(scheduledCallIds[0]);
+
+        // anyone can unschedule cancelled calls
+        agent.unscheduleCancelledCalls(scheduledCallIds);
+        assertEq(agent.getScheduledCallIds().length, 0);
+    }
+}

--- a/test/scenario/happy-path-plan-b.t.sol
+++ b/test/scenario/happy-path-plan-b.t.sol
@@ -4,9 +4,9 @@ import {Agent} from "contracts/Agent.sol";
 
 import "forge-std/Test.sol";
 
-import "./utils/mainnet-addresses.sol";
-import "./utils/interfaces.sol";
-import "./utils/utils.sol";
+import "../utils/mainnet-addresses.sol";
+import "../utils/interfaces.sol";
+import "../utils/utils.sol";
 
 
 abstract contract PlanBSetup is Test {

--- a/test/scenario/happy-path.t.sol
+++ b/test/scenario/happy-path.t.sol
@@ -1,13 +1,8 @@
 pragma solidity 0.8.23;
 
-import {ProxyAdmin} from "@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
-
 import {Agent} from "contracts/Agent.sol";
 import {Escrow} from "contracts/Escrow.sol";
-import {TransparentUpgradeableProxy} from "contracts/TransparentUpgradeableProxy.sol";
-import {Configuration} from "contracts/Configuration.sol";
 import {DualGovernance} from "contracts/DualGovernance.sol";
-import {AragonVotingSystem} from "contracts/voting-systems/AragonVotingSystem.sol";
 
 import "forge-std/Test.sol";
 
@@ -15,83 +10,7 @@ import "../utils/mainnet-addresses.sol";
 import "../utils/interfaces.sol";
 import "../utils/utils.sol";
 
-
-abstract contract DualGovernanceSetup is TestAssertions {
-    struct Deployed {
-        Agent agent;
-        AragonVotingSystem aragonVotingSystem;
-        DualGovernance dualGov;
-        TransparentUpgradeableProxy config;
-        ProxyAdmin configAdmin;
-    }
-
-    uint256 internal constant ARAGON_VOTING_SYSTEM_ID = 1;
-
-    function deployDG(
-        address daoAgent,
-        address daoVoting,
-        address ldoToken,
-        address stEth,
-        address wstEth,
-        address withdrawalQueue,
-        uint256 agentTimelockDuration,
-        address agentEmergencyMultisig,
-        uint256 agentEmergencyMultisigActiveFor
-    )
-        public
-        returns (Deployed memory d)
-    {
-        // deploy initial config impl
-        address configImpl = address(new Configuration());
-
-        // deploy config proxy
-        d.configAdmin = new ProxyAdmin(address(this));
-        d.config = new TransparentUpgradeableProxy(configImpl, address(d.configAdmin), new bytes(0));
-
-        // deploy agent and set its emergency multisig
-        d.agent = new Agent(daoAgent, address(this));
-        d.agent.forwardCall(address(d.agent), abi.encodeCall(
-            d.agent.setEmergencyMultisig, (
-                agentEmergencyMultisig,
-                agentEmergencyMultisigActiveFor
-            )
-        ));
-
-        // deploy aragon voting system facade
-        d.aragonVotingSystem = new AragonVotingSystem(daoVoting, ldoToken);
-
-        // deploy DG
-        address escrowImpl = address(new Escrow(address(d.config), stEth, wstEth, withdrawalQueue));
-        d.dualGov = new DualGovernance(
-            address(d.agent),
-            address(d.config),
-            configImpl,
-            address(d.configAdmin),
-            escrowImpl,
-            address(d.aragonVotingSystem)
-        );
-
-        // point Agent to the DG
-        d.agent.forwardCall(address(d.agent), abi.encodeCall(
-            d.agent.setGovernance, (
-                address(d.dualGov),
-                agentTimelockDuration
-            )
-        ));
-
-        // pass config proxy ownership to the DG
-        d.configAdmin.transferOwnership(address(d.dualGov));
-
-        // grant the aragon voting adapter the permission to create aragon votes
-        Utils.grantPermission(DAO_VOTING, IAragonVoting(DAO_VOTING).CREATE_VOTES_ROLE(), address(d.aragonVotingSystem));
-    }
-
-    function getAddress(bytes memory bytecode, uint256 salt) public view returns (address) {
-        bytes32 hash = keccak256(abi.encodePacked(bytes1(0xff), address(this), salt, keccak256(bytecode)));
-        return address(uint160(uint256(hash)));
-    }
-
-}
+import {DualGovernanceSetup} from "./setup.sol";
 
 
 abstract contract DualGovernanceUtils is TestAssertions {
@@ -114,8 +33,6 @@ abstract contract DualGovernanceUtils is TestAssertions {
 
 
 contract HappyPathTest is DualGovernanceSetup, DualGovernanceUtils {
-    using stdStorage for StdStorage;
-
     Agent internal agent;
     DualGovernance internal dualGov;
 

--- a/test/scenario/setup.sol
+++ b/test/scenario/setup.sol
@@ -1,0 +1,98 @@
+pragma solidity 0.8.23;
+
+import {ProxyAdmin} from "@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
+
+import {Agent} from "contracts/Agent.sol";
+import {Escrow} from "contracts/Escrow.sol";
+import {TransparentUpgradeableProxy} from "contracts/TransparentUpgradeableProxy.sol";
+import {Configuration} from "contracts/Configuration.sol";
+import {DualGovernance} from "contracts/DualGovernance.sol";
+import {AragonVotingSystem} from "contracts/voting-systems/AragonVotingSystem.sol";
+
+import "../utils/mainnet-addresses.sol";
+import "../utils/interfaces.sol";
+import "../utils/utils.sol";
+
+
+abstract contract DualGovernanceSetup is TestAssertions {
+    struct Deployed {
+        Agent agent;
+        AragonVotingSystem aragonVotingSystem;
+        DualGovernance dualGov;
+        TransparentUpgradeableProxy config;
+        ProxyAdmin configAdmin;
+    }
+
+    uint256 internal constant ARAGON_VOTING_SYSTEM_ID = 1;
+
+    function deployDG(
+        address daoAgent,
+        address daoVoting,
+        address ldoToken,
+        address stEth,
+        address wstEth,
+        address withdrawalQueue,
+        uint256 agentTimelockDuration,
+        address agentEmergencyMultisig,
+        uint256 agentEmergencyMultisigActiveFor
+    )
+        public
+        returns (Deployed memory d)
+    {
+        // deploy initial config impl
+        address configImpl = address(new Configuration());
+
+        // deploy config proxy
+        d.configAdmin = new ProxyAdmin(address(this));
+        d.config = new TransparentUpgradeableProxy(configImpl, address(d.configAdmin), new bytes(0));
+
+        // deploy agent and set its emergency multisig
+        d.agent = new Agent(daoAgent, address(this));
+        d.agent.forwardCall(address(d.agent), abi.encodeCall(
+            d.agent.setEmergencyMultisig, (
+                agentEmergencyMultisig,
+                agentEmergencyMultisigActiveFor
+            )
+        ));
+
+        console.log("Agent deployed to %x", address(d.agent));
+
+        // deploy aragon voting system facade
+        d.aragonVotingSystem = new AragonVotingSystem(daoVoting, ldoToken);
+
+        console.log("AragonVotingSystem deployed to %x", address(d.aragonVotingSystem));
+
+        // deploy DG
+        address escrowImpl = address(new Escrow(address(d.config), stEth, wstEth, withdrawalQueue));
+        d.dualGov = new DualGovernance(
+            address(d.agent),
+            address(d.config),
+            configImpl,
+            address(d.configAdmin),
+            escrowImpl,
+            address(d.aragonVotingSystem)
+        );
+
+        console.log("DG deployed to %x", address(d.dualGov));
+
+        // point Agent to the DG
+        d.agent.forwardCall(address(d.agent), abi.encodeCall(
+            d.agent.setGovernance, (
+                address(d.dualGov),
+                agentTimelockDuration
+            )
+        ));
+
+        // pass config proxy ownership to the DG
+        d.configAdmin.transferOwnership(address(d.dualGov));
+
+        // grant the aragon voting adapter the permission to create aragon votes
+        Utils.grantPermission(DAO_VOTING, IAragonVoting(DAO_VOTING).CREATE_VOTES_ROLE(), address(d.aragonVotingSystem));
+    }
+
+    function getAddress(bytes memory bytecode, uint256 salt) public view returns (address) {
+        bytes32 hash = keccak256(abi.encodePacked(bytes1(0xff), address(this), salt, keccak256(bytecode)));
+        return address(uint160(uint256(hash)));
+    }
+
+}

--- a/test/utils/utils.sol
+++ b/test/utils/utils.sol
@@ -20,13 +20,23 @@ abstract contract TestAssertions is Test {
 
 
 contract Target is TestAssertions {
+    bool internal _expectNoCalls;
     address internal _expectedCaller;
 
     function expectCalledBy(address expectedCaller) external {
+        _expectNoCalls = false;
         _expectedCaller = expectedCaller;
     }
 
+    function expectNoCalls() external {
+        _expectNoCalls = true;
+    }
+
     function doSmth(uint256 /* value */) external {
+        if (_expectNoCalls) {
+            console.log("unexpected call to %x by %x", address(this), msg.sender);
+            fail("expected no calls but got a call");
+        }
         if (_expectedCaller != address(0)) {
             assertEq(msg.sender, _expectedCaller, "unexpected caller");
             _expectedCaller = address(0);


### PR DESCRIPTION
### Breaking changes

`IVotingSystem.getProposalExecData` that previously returned a call to be made by the `Agent` is now replaced by `IVotingSystem.executeProposal` that is expected to trigger proposal execution, which provides more flexibility over how to execute the proposal for the particular voting system.

Not using the `Agent` by default for triggering proposal execution allows to avoid double timelock when `Agent` is in the timelocked mode and the proposal uses `DualGovernance.forwardCall`. The `IVotingSystem` adapter can still call `DualGovernance.forwardCall` by itself if it wants to execute the proposal directly.

### New functionality

Allow cleaning up scheduled but cancelled calls in the `Agent`.

### New tests

* Scenario: happy path with a timelocked `Agent`.
* Scenario: DG emergency deactivation by the emergency multisig.