### PR TITLE
DualGovernance and TImelock contracts tweaks

### DIFF
--- a/contracts/DualGovernance.sol
+++ b/contracts/DualGovernance.sol
@@ -112,27 +112,21 @@ contract DualGovernance {
     }
 
     function relay(uint256 proposalId) external {
-        GOV_STATE.activateNextState();
-        if (!GOV_STATE.isExecutionEnabled()) {
-            revert ExecutionForbidden();
-        }
-        Proposal memory proposal = _proposals.adopt(
-            proposalId,
-            CONFIG.minProposalExecutionTimelock()
-        );
+        Proposal memory proposal = _adopt(proposalId);
         TIMELOCK.relay(proposal.executor, proposal.calls);
     }
 
     function schedule(uint256 proposalId) external {
+        Proposal memory proposal = _adopt(proposalId);
+        TIMELOCK.schedule(proposalId, proposal.executor, proposal.calls);
+    }
+
+    function _adopt(uint256 proposalId) internal returns (Proposal memory proposal) {
         GOV_STATE.activateNextState();
         if (!GOV_STATE.isExecutionEnabled()) {
             revert ExecutionForbidden();
         }
-        Proposal memory proposal = _proposals.adopt(
-            proposalId,
-            CONFIG.minProposalExecutionTimelock()
-        );
-        TIMELOCK.schedule(proposalId, proposal.executor, proposal.calls);
+        proposal = _proposals.adopt(proposalId, CONFIG.minProposalExecutionTimelock());
     }
 
     function _getTime() internal view virtual returns (uint256) {

--- a/contracts/libraries/Proposers.sol
+++ b/contracts/libraries/Proposers.sol
@@ -63,7 +63,7 @@ library Proposers {
 
     function all(State storage self) internal view returns (Proposer[] memory proposers) {
         proposers = new Proposer[](self.proposers.length);
-        for (uint256 i = 0; i < proposers.length; ) {
+        for (uint256 i = 0; i < proposers.length; ++i) {
             proposers[i] = get(self, self.proposers[i]);
         }
     }


### PR DESCRIPTION
- Get rid of duplicated code in the `DualGovernance` contract in the `relay()` and `schedule()` methods
- Emergency mode deactivation may be done early only via governance proposal, not by emergency committee.
- Use `uint256` for ids in the libraries. Remove some unpacked versions of the structs.