### PR TITLE
Initial Kontrol property tests

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "lib/forge-std"]
 	path = lib/forge-std
 	url = https://github.com/foundry-rs/forge-std
+[submodule "lib/kontrol-cheatcodes"]
+	path = lib/kontrol-cheatcodes
+	url = https://github.com/runtimeverification/kontrol-cheatcodes

--- a/test/kontrol/VetoSignalling.t.sol
+++ b/test/kontrol/VetoSignalling.t.sol
@@ -117,6 +117,7 @@ contract VetoSignallingTest is Test, KontrolCheats {
         _storeAddress(address(signallingEscrow), 1, address(fakeETH));
         // Slot 3
         uint256 totalStaked = kevm.freshUInt(32); // ?WORD6
+        vm.assume(totalStaked < ethUpperBound);
         _storeUInt256(address(signallingEscrow), 3, totalStaked);
         // Slot 5
         uint256 totalClaimedEthAmount = kevm.freshUInt(32); // ?WORD7
@@ -138,6 +139,7 @@ contract VetoSignallingTest is Test, KontrolCheats {
         _storeAddress(address(rageQuitEscrow), 1, address(fakeETH));
         // Slot 3
         uint256 totalStaked = kevm.freshUInt(32); // ?WORD8
+        vm.assume(totalStaked < ethUpperBound);
         _storeUInt256(address(rageQuitEscrow), 3, totalStaked);
         // Slot 5
         uint256 totalClaimedEthAmount = kevm.freshUInt(32); // ?WORD9

--- a/test/kontrol/VetoSignalling.t.sol
+++ b/test/kontrol/VetoSignalling.t.sol
@@ -123,6 +123,9 @@ contract VetoSignallingTest is Test, KontrolCheats {
         uint256 totalClaimedEthAmount = kevm.freshUInt(32); // ?WORD7
         vm.assume(totalClaimedEthAmount <= totalStaked);
         _storeUInt256(address(signallingEscrow), 5, totalClaimedEthAmount);
+        // Slot 11
+        uint256 rageQuitExtensionDelayPeriodEnd = 0; // since SignallingEscrow
+        _storeUInt256(address(signallingEscrow), 11, rageQuitExtensionDelayPeriodEnd);
     }
 
     function _rageQuitEscrowStorageSetup() internal {
@@ -145,6 +148,9 @@ contract VetoSignallingTest is Test, KontrolCheats {
         uint256 totalClaimedEthAmount = kevm.freshUInt(32); // ?WORD9
         vm.assume(totalClaimedEthAmount <= totalStaked);
         _storeUInt256(address(rageQuitEscrow), 5, totalClaimedEthAmount);
+        // Slot 11
+        uint256 rageQuitExtensionDelayPeriodEnd = kevm.freshUInt(32); // ?WORD10
+        _storeUInt256(address(signallingEscrow), 11, rageQuitExtensionDelayPeriodEnd);
     }
 
     function _storeBytes32(address contractAddress, uint256 slot, bytes32 value) internal {
@@ -318,9 +324,9 @@ contract VetoSignallingTest is Test, KontrolCheats {
         StateRecord memory sr = _recordCurrentState(0);
 
         // Consider only the case where we have transitioned to Veto Signalling
-        vm.assume(sr.state == DualGovernance.State.VetoSignalling);
-
-        _vetoSignallingInvariants(Mode.Assert, sr);
+        if (sr.state == DualGovernance.State.VetoSignalling) {
+            _vetoSignallingInvariants(Mode.Assert, sr);
+        }
     }
 
     /**

--- a/test/kontrol/VetoSignalling.t.sol
+++ b/test/kontrol/VetoSignalling.t.sol
@@ -1,0 +1,398 @@
+pragma solidity 0.8.23;
+
+import "forge-std/Vm.sol";
+import "forge-std/Test.sol";
+import "kontrol-cheatcodes/KontrolCheats.sol";
+
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import "@openzeppelin/contracts/utils/math/Math.sol";
+
+import "contracts/model/DualGovernance.sol";
+import "contracts/model/EmergencyProtectedTimelock.sol";
+import "contracts/model/Escrow.sol";
+
+contract FakeETH is ERC20("fakeETH", "fETH") {}
+
+contract VetoSignallingTest is Test, KontrolCheats {
+    DualGovernance dualGovernance;
+    EmergencyProtectedTimelock timelock;
+    ERC20 fakeETH;
+    Escrow signallingEscrow;
+    Escrow rageQuitEscrow;
+
+    uint256 constant CURRENT_STATE_SLOT = 3;
+    uint256 constant CURRENT_STATE_OFFSET = 160;
+
+    // Note: there are lemmas dependent on `ethUpperBound`
+    uint256 constant ethMaxWidth = 96;
+    uint256 constant ethUpperBound = 2 ** ethMaxWidth;
+    uint256 constant timeUpperBound = 2 ** 40 - 1;
+
+    enum Mode {
+        Assume,
+        Assert
+    }
+
+    function _establish(Mode mode, bool condition) internal view {
+        if (mode == Mode.Assume) {
+            vm.assume(condition);
+        } else {
+            assert(condition);
+        }
+    }
+
+    function setUp() public {
+        fakeETH = new FakeETH();
+        uint256 emergencyProtectionTimelock = 0; // Regular deployment mode
+        dualGovernance = new DualGovernance(address(fakeETH), emergencyProtectionTimelock);
+        timelock = dualGovernance.emergencyProtectedTimelock();
+        signallingEscrow = dualGovernance.signallingEscrow();
+        rageQuitEscrow = new Escrow(address(dualGovernance), address(fakeETH));
+
+        _fakeETHStorageSetup();
+        _dualGovernanceStorageSetup();
+        _signallingEscrowStorageSetup();
+        _rageQuitEscrowStorageSetup();
+        kevm.symbolicStorage(address(timelock)); // ?STORAGE3
+    }
+
+    function _fakeETHStorageSetup() internal {
+        kevm.symbolicStorage(address(fakeETH)); // ?STORAGE
+        // Slot 2
+        uint256 totalSupply = kevm.freshUInt(32); // ?WORD
+        vm.assume(0 < totalSupply);
+        _storeUInt256(address(fakeETH), 2, totalSupply);
+    }
+
+    function _dualGovernanceStorageSetup() internal {
+        kevm.symbolicStorage(address(dualGovernance)); // ?STORAGE0
+        // Slot 0
+        _storeAddress(address(dualGovernance), 0, address(timelock));
+        // Slot 1
+        _storeAddress(address(dualGovernance), 1, address(signallingEscrow));
+        // Slot 2
+        _storeAddress(address(dualGovernance), 2, address(rageQuitEscrow));
+        // Slot 3
+        uint8 state = uint8(kevm.freshUInt(1)); // ?WORD0
+        vm.assume(state <= 4);
+        bytes memory slot_3_abi_encoding = abi.encodePacked(uint88(0), state, address(fakeETH));
+        bytes32 slot_3_for_storage;
+        assembly {
+            slot_3_for_storage := mload(add(slot_3_abi_encoding, 0x20))
+        }
+        _storeBytes32(address(dualGovernance), 3, slot_3_for_storage);
+        // Slot 6
+        uint256 lastStateChangeTime = kevm.freshUInt(32); // ?WORD1
+        vm.assume(lastStateChangeTime <= block.timestamp);
+        _storeUInt256(address(dualGovernance), 6, lastStateChangeTime);
+        // Slot 7
+        uint256 lastSubStateActivationTime = kevm.freshUInt(32); // ?WORD2
+        vm.assume(lastSubStateActivationTime <= block.timestamp);
+        _storeUInt256(address(dualGovernance), 7, lastSubStateActivationTime);
+        // Slot 8
+        uint256 lastStateReactivationTime = kevm.freshUInt(32); // ?WORD3
+        vm.assume(lastStateReactivationTime <= block.timestamp);
+        _storeUInt256(address(dualGovernance), 8, lastStateReactivationTime);
+        // Slot 9
+        uint256 lastVetoSignallingTime = kevm.freshUInt(32); // ?WORD4
+        vm.assume(lastVetoSignallingTime <= block.timestamp);
+        _storeUInt256(address(dualGovernance), 9, lastVetoSignallingTime);
+        // Slot 10
+        uint256 rageQuitSequenceNumber = kevm.freshUInt(32); // ?WORD5
+        vm.assume(rageQuitSequenceNumber < type(uint256).max);
+        _storeUInt256(address(dualGovernance), 10, rageQuitSequenceNumber);
+    }
+
+    function _signallingEscrowStorageSetup() internal {
+        kevm.symbolicStorage(address(signallingEscrow)); // ?STORAGE1
+        // Slot 0: currentState == 0 (SignallingEscrow), dualGovernance
+        uint8 currentState = 0;
+        bytes memory slot_0_abi_encoding = abi.encodePacked(uint88(0), address(dualGovernance), currentState);
+        bytes32 slot_0_for_storage;
+        assembly {
+            slot_0_for_storage := mload(add(slot_0_abi_encoding, 0x20))
+        }
+        _storeBytes32(address(signallingEscrow), 0, slot_0_for_storage);
+        // Slot 1
+        _storeAddress(address(signallingEscrow), 1, address(fakeETH));
+        // Slot 3
+        uint256 totalStaked = kevm.freshUInt(32); // ?WORD6
+        _storeUInt256(address(signallingEscrow), 3, totalStaked);
+        // Slot 5
+        uint256 totalClaimedEthAmount = kevm.freshUInt(32); // ?WORD7
+        vm.assume(totalClaimedEthAmount <= totalStaked);
+        _storeUInt256(address(signallingEscrow), 5, totalClaimedEthAmount);
+    }
+
+    function _rageQuitEscrowStorageSetup() internal {
+        kevm.symbolicStorage(address(rageQuitEscrow)); // ?STORAGE2
+        // Slot 0: currentState == 1 (RageQuitEscrow), dualGovernance
+        uint8 currentState = 1;
+        bytes memory slot_0_abi_encoding = abi.encodePacked(uint88(0), address(dualGovernance), currentState);
+        bytes32 slot_0_for_storage;
+        assembly {
+            slot_0_for_storage := mload(add(slot_0_abi_encoding, 0x20))
+        }
+        _storeBytes32(address(rageQuitEscrow), 0, slot_0_for_storage);
+        // Slot 1
+        _storeAddress(address(rageQuitEscrow), 1, address(fakeETH));
+        // Slot 3
+        uint256 totalStaked = kevm.freshUInt(32); // ?WORD8
+        _storeUInt256(address(rageQuitEscrow), 3, totalStaked);
+        // Slot 5
+        uint256 totalClaimedEthAmount = kevm.freshUInt(32); // ?WORD9
+        vm.assume(totalClaimedEthAmount <= totalStaked);
+        _storeUInt256(address(rageQuitEscrow), 5, totalClaimedEthAmount);
+    }
+
+    function _storeBytes32(address contractAddress, uint256 slot, bytes32 value) internal {
+        vm.store(contractAddress, bytes32(slot), value);
+    }
+
+    function _storeUInt256(address contractAddress, uint256 slot, uint256 value) internal {
+        vm.store(contractAddress, bytes32(slot), bytes32(value));
+    }
+
+    function _storeAddress(address contractAddress, uint256 slot, address value) internal {
+        vm.store(contractAddress, bytes32(slot), bytes32(uint256(uint160(value))));
+    }
+
+    struct StateRecord {
+        DualGovernance.State state;
+        uint256 timestamp;
+        uint256 rageQuitSupport;
+        uint256 maxRageQuitSupport;
+        uint256 activationTime;
+        uint256 reactivationTime;
+    }
+
+    /**
+     * Invariants that should hold while in the Veto Signalling state
+     * (including Deactivation sub-state)
+     */
+    function _vetoSignallingInvariants(Mode mode, StateRecord memory sr) internal view {
+        require(
+            sr.state != DualGovernance.State.Normal && sr.state != DualGovernance.State.VetoCooldown
+                && sr.state != DualGovernance.State.RageQuit,
+            "Invariants only apply to the Veto Signalling states."
+        );
+
+        _vetoSignallingTimesInvariant(mode, sr);
+        _vetoSignallingRageQuitInvariant(mode, sr);
+        _vetoSignallingDeactivationInvariant(mode, sr);
+        _vetoSignallingMaxDelayInvariant(mode, sr);
+    }
+
+    /**
+     * Veto Signalling Invariant: At any given point t up to the present time,
+     * the Veto Signalling activation and reactivation times must be before t.
+     */
+    function _vetoSignallingTimesInvariant(Mode mode, StateRecord memory sr) internal view {
+        _establish(mode, sr.timestamp <= block.timestamp);
+        _establish(mode, sr.activationTime <= sr.timestamp);
+        _establish(mode, sr.reactivationTime <= sr.timestamp);
+    }
+
+    /**
+     * Veto Signalling Invariant: The rage quit support cannot be greater than
+     * the maximum rage quit support since entering the Veto Signalling state,
+     * and the maximum rage quit support must be greater than the first seal
+     * threshold.
+     */
+    function _vetoSignallingRageQuitInvariant(Mode mode, StateRecord memory sr) internal view {
+        _establish(mode, sr.rageQuitSupport <= sr.maxRageQuitSupport);
+        _establish(mode, dualGovernance.FIRST_SEAL_RAGE_QUIT_SUPPORT() < sr.maxRageQuitSupport);
+    }
+
+    /**
+     * Veto Signalling Invariant: If at a given time both the dynamic timelock
+     * for the current rage quit support AND the minimum active duration since
+     * the Deactivation sub-state was last exited have passed, the protocol is
+     * in the Deactivation sub-state. Otherwise, it is in the parent state.
+     */
+    function _vetoSignallingDeactivationInvariant(Mode mode, StateRecord memory sr) internal view {
+        uint256 dynamicTimelock = dualGovernance.calculateDynamicTimelock(sr.rageQuitSupport);
+
+        // Note: creates three branches in symbolic execution
+        if (sr.timestamp <= sr.activationTime + dynamicTimelock) {
+            _establish(mode, sr.state == DualGovernance.State.VetoSignalling);
+        } else if (
+            sr.timestamp
+                <= Math.max(sr.reactivationTime, sr.activationTime) + dualGovernance.VETO_SIGNALLING_MIN_ACTIVE_DURATION()
+        ) {
+            _establish(mode, sr.state == DualGovernance.State.VetoSignalling);
+        } else {
+            _establish(mode, sr.state == DualGovernance.State.VetoSignallingDeactivation);
+        }
+    }
+
+    /**
+     * Veto Signalling Invariant: If the maximum deactivation delay has passed,
+     * then the protocol must be in the Deactivation sub-state.
+     *
+     * The maximum deactivation delay is defined as T + D, where
+     * - T is the dynamic timelock for the maximum rage quit support obtained
+     *   since entering the Veto Signalling state, and
+     * - D is the minimum active duration before the Deactivation sub-state can
+     *   be re-entered.
+     */
+    function _vetoSignallingMaxDelayInvariant(Mode mode, StateRecord memory sr) internal view {
+        // Note: creates two branches in symbolic execution
+        if (_maxDeactivationDelayPassed(sr)) {
+            _establish(mode, sr.state == DualGovernance.State.VetoSignallingDeactivation);
+        }
+    }
+
+    function _maxDeactivationDelayPassed(StateRecord memory sr) internal view returns (bool) {
+        uint256 maxDeactivationDelay = dualGovernance.calculateDynamicTimelock(sr.maxRageQuitSupport)
+            + dualGovernance.VETO_SIGNALLING_MIN_ACTIVE_DURATION();
+
+        return sr.activationTime + maxDeactivationDelay < sr.timestamp;
+    }
+
+    function _recordPreviousState(
+        uint256 lastInteractionTimestamp,
+        uint256 previousRageQuitSupport,
+        uint256 maxRageQuitSupport
+    ) internal view returns (StateRecord memory sr) {
+        sr.state = dualGovernance.currentState();
+        sr.timestamp = lastInteractionTimestamp;
+        sr.rageQuitSupport = previousRageQuitSupport;
+        sr.maxRageQuitSupport = maxRageQuitSupport;
+        sr.activationTime = dualGovernance.lastStateChangeTime();
+        sr.reactivationTime = dualGovernance.lastStateReactivationTime();
+    }
+
+    function _recordCurrentState(uint256 previousMaxRageQuitSupport) internal view returns (StateRecord memory sr) {
+        sr.state = dualGovernance.currentState();
+        sr.timestamp = block.timestamp;
+        sr.rageQuitSupport = signallingEscrow.getRageQuitSupport();
+        sr.maxRageQuitSupport =
+            previousMaxRageQuitSupport < sr.rageQuitSupport ? sr.rageQuitSupport : previousMaxRageQuitSupport;
+        sr.activationTime = dualGovernance.lastStateChangeTime();
+        sr.reactivationTime = dualGovernance.lastStateReactivationTime();
+    }
+
+    /**
+     * Together, the three tests below verify the following:
+     *
+     * 1. After entering the Veto Signalling state, the Deactivation sub-state
+     *    will be entered in at most time proportional to the maximum rage quit
+     *    support observed since entering the Veto Signalling state.
+     *
+     * 2. If a new maximum rage quit support is not observed after this time,
+     *    the Deactivation sub-state will not exit back to the parent state, and
+     *    therefore the Veto Cooldown state will be entered after the maximum
+     *    deactivation duration has elapsed.
+     *
+     * This places a bound on the maximum time that the protocol can be forced
+     * to stay in the Veto Signalling state.
+     */
+
+    /**
+     * Test that the Veto Signalling invariants hold when the Veto Signalling
+     * state is first entered.
+     */
+    function testVetoSignallingInvariantsHoldInitially() external {
+        vm.assume(block.timestamp < timeUpperBound);
+
+        vm.assume(dualGovernance.currentState() != DualGovernance.State.VetoSignalling);
+        vm.assume(dualGovernance.currentState() != DualGovernance.State.VetoSignallingDeactivation);
+
+        dualGovernance.activateNextState();
+
+        StateRecord memory sr = _recordCurrentState(0);
+
+        // Consider only the case where we have transitioned to Veto Signalling
+        vm.assume(sr.state == DualGovernance.State.VetoSignalling);
+
+        _vetoSignallingInvariants(Mode.Assert, sr);
+    }
+
+    /**
+     * Assuming that the previous state of the protocol is consistent with the
+     * Veto Signalling invariants, test that when we call activateNextState()
+     * the state remains consistent with the invariants.
+     */
+    function testVetoSignallingInvariantsArePreserved(
+        uint256 lastInteractionTimestamp,
+        uint256 previousRageQuitSupport,
+        uint256 maxRageQuitSupport
+    ) external {
+        vm.assume(block.timestamp < timeUpperBound);
+
+        vm.assume(lastInteractionTimestamp < timeUpperBound);
+        vm.assume(previousRageQuitSupport < ethUpperBound);
+        vm.assume(maxRageQuitSupport < ethUpperBound);
+
+        // Temporary assumptions
+        vm.assume(previousRageQuitSupport <= 1);
+        vm.assume(10 <= maxRageQuitSupport);
+        vm.assume(
+            lastInteractionTimestamp
+                <= dualGovernance.lastStateChangeTime() + dualGovernance.calculateDynamicTimelock(previousRageQuitSupport)
+        );
+        // Temparary assumptions
+
+        StateRecord memory previous =
+            _recordPreviousState(lastInteractionTimestamp, previousRageQuitSupport, maxRageQuitSupport);
+
+        vm.assume(previous.state != DualGovernance.State.Normal);
+        vm.assume(previous.state != DualGovernance.State.VetoCooldown);
+        vm.assume(previous.state != DualGovernance.State.RageQuit);
+
+        _vetoSignallingInvariants(Mode.Assume, previous);
+        dualGovernance.activateNextState();
+
+        StateRecord memory current = _recordCurrentState(maxRageQuitSupport);
+
+        if (
+            current.state != DualGovernance.State.Normal && current.state != DualGovernance.State.VetoCooldown
+                && current.state != DualGovernance.State.RageQuit
+        ) {
+            _vetoSignallingInvariants(Mode.Assert, current);
+        }
+    }
+
+    /**
+     * Test that, given the Veto Signalling invariants, then if
+     * a) the maximum deactivation delay passes, and
+     * b) we don't observe a new maximum rage quit support,
+     * then the protocol cannot have exited the Deactivation sub-state.
+     */
+    function testDeactivationNotCancelled(
+        uint256 lastInteractionTimestamp,
+        uint256 previousRageQuitSupport,
+        uint256 maxRageQuitSupport
+    ) external {
+        StateRecord memory previous =
+            _recordPreviousState(lastInteractionTimestamp, previousRageQuitSupport, maxRageQuitSupport);
+
+        vm.assume(_maxDeactivationDelayPassed(previous));
+        vm.assume(signallingEscrow.getRageQuitSupport() <= previous.maxRageQuitSupport);
+
+        vm.assume(
+            previous.state == DualGovernance.State.VetoSignalling
+                || previous.state == DualGovernance.State.VetoSignallingDeactivation
+        );
+
+        _vetoSignallingInvariants(Mode.Assume, previous);
+
+        assert(previous.state == DualGovernance.State.VetoSignallingDeactivation);
+
+        dualGovernance.activateNextState();
+
+        StateRecord memory current = _recordCurrentState(maxRageQuitSupport);
+
+        uint256 deactivationStartTime = dualGovernance.lastSubStateActivationTime();
+        uint256 deactivationEndTime = deactivationStartTime + dualGovernance.VETO_SIGNALLING_DEACTIVATION_MAX_DURATION();
+
+        // The protocol is either in the Deactivation sub-state, or, if the
+        // maximum deactivation duration has passed, in the Veto Cooldown state
+        if (deactivationEndTime < block.timestamp) {
+            assert(current.state == DualGovernance.State.VetoCooldown);
+        } else {
+            assert(current.state == DualGovernance.State.VetoSignallingDeactivation);
+        }
+    }
+}

--- a/test/kontrol/VetoSignalling.t.sol
+++ b/test/kontrol/VetoSignalling.t.sol
@@ -157,6 +157,18 @@ contract VetoSignallingTest is Test, KontrolCheats {
         vm.store(contractAddress, bytes32(slot), bytes32(uint256(uint160(value))));
     }
 
+    /**
+     * Test that the Normal state transitions to VetoSignalling if the total
+     * veto power in the signalling escrow exceeds the first seal threshold.
+     */
+    function testTransitionNormalToVetoSignalling() external {
+        uint256 rageQuitSupport = signallingEscrow.getRageQuitSupport();
+        vm.assume(rageQuitSupport > dualGovernance.FIRST_SEAL_RAGE_QUIT_SUPPORT());
+        vm.assume(dualGovernance.currentState() == DualGovernance.State.Normal);
+        dualGovernance.activateNextState();
+        assert(dualGovernance.currentState() == DualGovernance.State.VetoSignalling);
+    }
+
     struct StateRecord {
         DualGovernance.State state;
         uint256 timestamp;

--- a/test/kontrol/lido-lemmas.k
+++ b/test/kontrol/lido-lemmas.k
@@ -1,0 +1,239 @@
+requires "foundry.md"
+
+module LIDO-LEMMAS
+    imports FOUNDRY
+    imports INT-SYMBOLIC
+    imports MAP-SYMBOLIC
+    imports SET-SYMBOLIC
+
+    syntax StepSort ::= Int
+                      | Bool
+                      | Bytes
+                      | Set
+ // -------------------------
+
+    syntax KItem ::= runLemma ( StepSort )
+                   | doneLemma( StepSort )
+ // --------------------------------------
+    rule <k> runLemma(T) => doneLemma(T) ... </k>
+
+    syntax Int ::= "ethMaxWidth" [macro]
+    syntax Int ::= "ethUpperBound" [macro]
+ // --------------------------------------
+    rule ethMaxWidth => 96
+    rule ethUpperBound => 2 ^Int ethMaxWidth
+ // ----------------------------------------
+
+    // /Int to byte representation
+    rule X /Int pow160 => #asWord ( #range ( #buf ( 32 , X ) , 0 , 12 ) )
+      requires #rangeUInt(256, X)
+      [simplification, preserves-definedness]
+
+    // Deconstruction of mask
+    rule 115792089237316195423570984636004990333889740523700931696805413995650331181055 &Int X =>
+            #asWord ( #range(#buf(32, X), 0, 11) +Bytes #buf(1, 0) +Bytes #range(#buf(32, X), 12, 20) )
+      requires #rangeUInt(256, X)
+      [simplification]
+
+    // |Int distributivity over #asWord and +Bytes, v1
+    rule A |Int #asWord ( BA1 +Bytes BA2 ) =>
+      #asWord ( BA1 +Bytes #buf ( lengthBytes(BA2), A |Int #asWord ( BA2 ) ) )
+      requires 0 <=Int A andBool A <Int 2 ^Int (8 *Int lengthBytes(BA2))
+      [concrete(A), simplification]
+
+    // |Int distributivity over #asWord and +Bytes, v2
+    rule A |Int #asWord ( BA1 +Bytes BA2 ) =>
+      #asWord (
+        #buf ( lengthBytes(BA1), (A >>Int (8 *Int lengthBytes(BA2))) |Int #asWord ( BA1 ) )
+        +Bytes
+        #buf ( lengthBytes(BA2), (A modInt (2 ^Int (8 *Int lengthBytes(BA2)))) |Int #asWord ( BA2 ) )
+      )
+      requires #rangeUInt(256, A)
+      [simplification, concrete(A, BA1)]
+
+    // |Int and #asWord
+    rule #range ( #buf ( A, X |Int Y) , 0, B ) =>
+      #buf ( B, X >>Int (8 *Int (A -Int B)) )
+      requires B <=Int A
+       andBool 0 <=Int X andBool X <Int 2 ^Int (8 *Int A)
+       andBool 0 <=Int Y andBool Y <Int 2 ^Int (8 *Int (A -Int B))
+      [simplification, concrete(A, B)]
+
+    // chop and -Int
+    rule chop (A +Int B) ==Int 0 => A ==Int (-1) *Int B
+      requires #rangeUInt(256, A) andBool #rangeUInt(256, (-1) *Int B)
+      [concrete(B), simplification, comm]
+
+    // *Int
+    rule A *Int B ==Int 0 => A ==Int 0 orBool B ==Int 0 [simplification]
+
+    // /Int
+    rule 0 /Int B         => 0         requires B =/=Int 0 [simplification, preserves-definedness]
+    rule A /Int B ==Int 0 => A ==Int 0 requires B =/=Int 0 [simplification, preserves-definedness]
+
+    // /Word
+    rule  _ /Word W1 => 0          requires W1  ==Int 0 [simplification]
+    rule W0 /Word W1 => W0 /Int W1 requires W1 =/=Int 0 [simplification, preserves-definedness]
+
+    // Further arithmetic
+    rule ( X *Int Y ) /Int Y => X requires Y =/=Int 0              [simplification, preserves-definedness]
+    rule ( X ==Int ( X *Int Y ) /Word Y ) orBool Y ==Int 0 => true [simplification, preserves-definedness]
+
+    rule A <=Int B /Int C =>         A  *Int C <=Int B requires 0 <Int C [simplification, preserves-definedness]
+    rule A  <Int B /Int C => (A +Int 1) *Int C <=Int B requires 0 <Int C [simplification, preserves-definedness]
+    rule A  >Int B /Int C =>         A  *Int C  >Int B requires 0 <Int C [simplification, preserves-definedness]
+    rule A >=Int B /Int C => (A +Int 1) *Int C  >Int B requires 0 <Int C [simplification, preserves-definedness]
+
+    rule B /Int C >=Int A =>         A  *Int C <=Int B requires 0 <Int C [simplification, preserves-definedness]
+    rule B /Int C  >Int A => (A +Int 1) *Int C <=Int B requires 0 <Int C [simplification, preserves-definedness]
+    rule B /Int C  <Int A =>         A  *Int C  >Int B requires 0 <Int C [simplification, preserves-definedness]
+    rule B /Int C <=Int A => (A +Int 1) *Int C  >Int B requires 0 <Int C [simplification, preserves-definedness]
+
+    // Further generalization of: maxUIntXXX &Int #asWord ( BA )
+    rule X &Int #asWord ( BA ) => #asWord ( #range(BA, lengthBytes(BA) -Int (log2Int(X +Int 1) /Int 8), log2Int(X +Int 1) /Int 8) )
+    requires #rangeUInt(256, X)
+     andBool X +Int 1 ==Int 2 ^Int log2Int(X +Int 1)
+     andBool log2Int (X +Int 1) modInt 8 ==Int 0
+     andBool (log2Int (X +Int 1)) /Int 8 <=Int lengthBytes(BA) andBool lengthBytes(BA) <=Int 32
+     [simplification, concrete(X), preserves-definedness]
+
+    // &Int distributivity
+    rule X &Int ( Y |Int Z ) => ( X &Int Y ) |Int ( X &Int Z ) [simplification, concrete(X)]
+    rule X &Int ( Y &Int Z ) => ( X &Int Y ) &Int ( X &Int Z ) [simplification, concrete(X)]
+
+    // KEVM simplification
+    rule #asWord(WS) >>Int M => #asWord(#range(WS, 0, lengthBytes(WS) -Int (M /Int 8) ))
+    requires 0 <=Int M andBool M modInt 8 ==Int 0
+    [simplification, preserves-definedness]
+
+    //
+    // .Bytes
+    //
+    rule .Bytes ==K b"" => true [simplification, comm]
+
+    rule    b"" ==K #buf(X, _) +Bytes _ => false requires 0 <Int X [simplification, concrete(X), comm]
+    rule    b"" ==K _ +Bytes #buf(X, _) => false requires 0 <Int X [simplification, concrete(X), comm]
+    rule .Bytes ==K #buf(X, _) +Bytes _ => false requires 0 <Int X [simplification, concrete(X), comm]
+    rule .Bytes ==K _ +Bytes #buf(X, _) => false requires 0 <Int X [simplification, concrete(X), comm]
+
+    rule [concat-neutral-left]:  b"" +Bytes B:Bytes => B:Bytes [simplification]
+    rule [concat-neutral-right]: B:Bytes +Bytes b"" => B:Bytes [simplification]
+
+    //
+    // Alternative memory update
+    //
+    rule [memUpdate-concat-in-right]: (B1 +Bytes B2) [ S := B ] => B1 +Bytes (B2 [ S -Int lengthBytes(B1) := B ])
+      requires lengthBytes(B1) <=Int S
+      [simplification(40)]
+
+    rule [memUpdate-concat-in-left]: (B1 +Bytes B2) [ S := B ] => (B1 [S := B]) +Bytes B2
+      requires 0 <=Int S andBool S +Int lengthBytes(B) <=Int lengthBytes(B1)
+      [simplification(45)]
+
+    //
+    // Specific simplifications
+    //
+    rule X &Int #asWord ( BA ) ==Int Y:Int => true
+    requires 0 <=Int X andBool X <Int 2 ^Int (8 *Int lengthBytes(BA))
+     andBool X +Int 1 ==Int 2 ^Int log2Int(X +Int 1)
+     andBool log2Int (X +Int 1) modInt 8 ==Int 0
+     andBool #asWord ( #range(BA, lengthBytes(BA) -Int (log2Int(X +Int 1) /Int 8), log2Int(X +Int 1) /Int 8) ) ==Int Y:Int
+     [simplification, concrete(X), comm, preserves-definedness]
+
+    rule X &Int #asWord ( BA ) ==Int Y:Int => false
+    requires 0 <=Int X andBool X <Int 2 ^Int (8 *Int lengthBytes(BA))
+     andBool X +Int 1 ==Int 2 ^Int log2Int(X +Int 1)
+     andBool log2Int (X +Int 1) modInt 8 ==Int 0
+     andBool notBool #asWord ( #range(BA, lengthBytes(BA) -Int (log2Int(X +Int 1) /Int 8), log2Int(X +Int 1) /Int 8) ) ==Int Y:Int
+     [simplification, concrete(X), comm, preserves-definedness]
+
+    rule X &Int #asWord ( BA ) <Int Y:Int => true
+    requires 0 <=Int X andBool X <Int 2 ^Int (8 *Int lengthBytes(BA))
+     andBool X +Int 1 ==Int 2 ^Int log2Int(X +Int 1)
+     andBool log2Int (X +Int 1) modInt 8 ==Int 0
+     andBool #asWord ( #range(BA, lengthBytes(BA) -Int (log2Int(X +Int 1) /Int 8), log2Int(X +Int 1) /Int 8) ) <Int Y:Int
+     [simplification, concrete(X), preserves-definedness]
+
+    rule X &Int #asWord ( BA ) <Int Y:Int => false
+    requires 0 <=Int X andBool X <Int 2 ^Int (8 *Int lengthBytes(BA))
+     andBool X +Int 1 ==Int 2 ^Int log2Int(X +Int 1)
+     andBool log2Int (X +Int 1) modInt 8 ==Int 0
+     andBool notBool #asWord ( #range(BA, lengthBytes(BA) -Int (log2Int(X +Int 1) /Int 8), log2Int(X +Int 1) /Int 8) ) <Int Y:Int
+     [simplification, concrete(X), preserves-definedness]
+
+    rule X &Int #asWord ( BA ) <=Int Y:Int => true
+    requires 0 <=Int X andBool X <Int 2 ^Int (8 *Int lengthBytes(BA))
+     andBool X +Int 1 ==Int 2 ^Int log2Int(X +Int 1)
+     andBool log2Int (X +Int 1) modInt 8 ==Int 0
+     andBool #asWord ( #range(BA, lengthBytes(BA) -Int (log2Int(X +Int 1) /Int 8), log2Int(X +Int 1) /Int 8) ) <=Int Y:Int
+     [simplification, concrete(X), preserves-definedness]
+
+    rule X &Int #asWord ( BA ) <=Int Y:Int => false
+    requires 0 <=Int X andBool X <Int 2 ^Int (8 *Int lengthBytes(BA))
+     andBool X +Int 1 ==Int 2 ^Int log2Int(X +Int 1)
+     andBool log2Int (X +Int 1) modInt 8 ==Int 0
+     andBool notBool #asWord ( #range(BA, lengthBytes(BA) -Int (log2Int(X +Int 1) /Int 8), log2Int(X +Int 1) /Int 8) ) <=Int Y:Int
+     [simplification, concrete(X), preserves-definedness]
+
+    rule X &Int ( Y *Int Z ) => 0
+    requires 0 <=Int X andBool 0 <=Int Y andBool 0 <=Int Z
+     andBool X +Int 1 ==Int 2 ^Int log2Int(X +Int 1)
+     andBool Y ==Int 2 ^Int log2Int(Y)
+     andBool log2Int(X +Int 1) <=Int log2Int(Y)
+     [simplification, concrete(X, Y), preserves-definedness]
+
+    rule X &Int ( Y *Int Z ) => 0
+    requires 0 <=Int X andBool 0 <=Int Y andBool 0 <=Int Z
+     andBool X +Int 1 ==Int 2 ^Int log2Int(X +Int 1)
+     andBool Z ==Int 2 ^Int log2Int(Z)
+     andBool log2Int(X +Int 1) <=Int log2Int(Z)
+     [simplification, concrete(X, Z), preserves-definedness]
+
+    rule chop ( X *Int Y ) => X *Int Y
+      requires 0 <=Int X andBool X <Int ethUpperBound
+       andBool 0 <=Int Y andBool Y <Int 2 ^Int ( 256 -Int ethMaxWidth )
+       [simplification]
+
+    rule [mul-overflow-check]:
+      X ==Int chop ( X *Int Y ) /Int Y => X *Int Y <Int pow256
+      requires #rangeUInt(256, X) andBool 0 <Int Y
+      [simplification, comm, preserves-definedness]
+
+    rule [mul-overflow-check-ML]:
+      { X #Equals chop ( X *Int Y ) /Int Y } => { true #Equals X *Int Y <Int pow256 }
+      requires #rangeUInt(256, X) andBool 0 <Int Y
+      [simplification, preserves-definedness]
+
+    rule 0 <=Int keccak(X) => true [simplification, smt-lemma]
+
+    rule X >>Int N => X /Int (2 ^Int N) [simplification, concrete(N)]
+
+    rule #asWord ( BUF1 +Bytes BUF2 ) => #asWord ( BUF2 )
+        requires #asWord ( BUF1 ) ==Int 0
+        [simplification, concrete(BUF1)]
+
+endmodule
+
+module LIDO-LEMMAS-SPEC
+    imports LIDO-LEMMAS
+
+    claim [storage-offset]: <k> runLemma ( ( #lookup ( STORAGE3:Map , 2 ) /Int pow160 ) ) => doneLemma ( #asWord ( #range ( #buf ( 32 , #lookup ( STORAGE3:Map , 2 ) ) , 0 , 12 ) ) ) ... </k>
+
+    claim [chop-simplify]: <k> runLemma (
+                                 notBool chop ( WORD7:Int +Int ( WORD12:Int *Int ( ( WORD5:Int -Int WORD6:Int ) /Int WORD11:Int ) ) ) ==Int
+                                 chop ( chop ( WORD7:Int +Int ( WORD12:Int *Int ( ( WORD5:Int -Int WORD6:Int ) /Int WORD11:Int ) ) ) *Int 1000000000000000000 ) /Int 1000000000000000000
+                               ) => runLemma ( false ) ... </k>
+      requires 0 <=Int WORD5:Int
+       andBool 0 <=Int WORD6:Int
+       andBool 0 <=Int WORD7:Int
+       andBool 0 <=Int WORD11:Int
+       andBool 0 <=Int WORD12:Int
+       andBool WORD11:Int =/=Int 0
+       andBool WORD12:Int =/=Int 0
+       andBool WORD6:Int <=Int WORD5:Int
+       andBool WORD5:Int <Int pow96
+       andBool WORD6:Int <Int pow96
+       andBool WORD7:Int <Int pow96
+       andBool WORD11:Int <Int pow96
+       andBool WORD12:Int <Int pow96
+endmodule


### PR DESCRIPTION
Depends on #45.

Initial set of symbolic property tests written by RV on top of the abstract model from PR #45, to be verified using the Kontrol tool. This set of tests focuses on the invariants of the Veto Signalling state and on using these invariants to bound how long the protocol can remain in that state relative to the rage quit support.