### PR TITLE
Solidity warnings fixes

### DIFF
--- a/test/scenario/escrow.t.sol
+++ b/test/scenario/escrow.t.sol
@@ -201,7 +201,6 @@ contract EscrowHappyPath is ScenarioTestBlueprint {
     }
 
     function test_check_finalization() public {
-        uint256 totalAmountLocked = 2 ether;
         uint256[] memory amounts = new uint256[](2);
         for (uint256 i = 0; i < 2; ++i) {
             amounts[i] = 1 ether;
@@ -345,7 +344,7 @@ contract EscrowHappyPath is ScenarioTestBlueprint {
         // unstETH holders claim their withdrawal requests
         // ---
         {
-            uint256[] memory hints =
+            hints =
                 _lido.withdrawalQueue.findCheckpointHints(unstETHIds, 1, _lido.withdrawalQueue.getLastCheckpointIndex());
             escrow.claimUnstETH(unstETHIds, hints);
 

--- a/test/scenario/happy-path-plan-b.t.sol
+++ b/test/scenario/happy-path-plan-b.t.sol
@@ -246,7 +246,7 @@ contract PlanBSetup is ScenarioTestBlueprint {
 
             assertFalse(_timelock.isEmergencyModeActive());
 
-            EmergencyProtection.Context memory emergencyState = _timelock.getEmergencyProtectionContext();
+            emergencyState = _timelock.getEmergencyProtectionContext();
             assertEq(emergencyState.emergencyActivationCommittee, address(_emergencyActivationCommittee));
             assertEq(emergencyState.emergencyExecutionCommittee, address(_emergencyExecutionCommittee));
             assertEq(emergencyState.emergencyModeDuration, Durations.from(30 days));

--- a/test/scenario/proposal-deployment-modes.t.sol
+++ b/test/scenario/proposal-deployment-modes.t.sol
@@ -90,7 +90,7 @@ contract ProposalDeploymentModesTest is ScenarioTestBlueprint {
     function test_protected_deployment_mode_deactivation_in_emergency_mode() external {
         _deployDualGovernanceSetup(true);
 
-        (uint256 proposalId, ExternalCall[] memory regularStaffCalls) = _createAndAssertProposal();
+        (uint256 proposalId,) = _createAndAssertProposal();
 
         _wait(_timelock.getAfterSubmitDelay().dividedBy(2));
 

--- a/test/utils/scenario-test-blueprint.sol
+++ b/test/utils/scenario-test-blueprint.sol
@@ -124,13 +124,6 @@ contract ScenarioTestBlueprint is TestingAssertEqExtender, SetupDeployment {
         _lido.submitWstETH(account, _lido.calcSharesToDepositFromPercentageOfTVL(tvlPercentage));
     }
 
-    function _submitStETH(
-        address account,
-        uint256 amountToMint
-    ) internal returns (uint256 sharesMinted, uint256 amountMinted) {
-        _lido.submitStETH(account, amountToMint);
-    }
-
     function _getBalances(address vetoer) internal view returns (Balances memory balances) {
         uint256 stETHAmount = _lido.stETH.balanceOf(vetoer);
         uint256 wstETHShares = _lido.wstETH.balanceOf(vetoer);
@@ -469,7 +462,7 @@ contract ScenarioTestBlueprint is TestingAssertEqExtender, SetupDeployment {
     // ---
     // Logging and Debugging
     // ---
-    function _logVetoSignallingState() internal {
+    function _logVetoSignallingState() internal view {
         /* solhint-disable no-console */
         (bool isActive, uint256 duration, uint256 activatedAt, uint256 enteredAt) = _getVetoSignallingState();
 
@@ -494,7 +487,7 @@ contract ScenarioTestBlueprint is TestingAssertEqExtender, SetupDeployment {
         /* solhint-enable no-console */
     }
 
-    function _logVetoSignallingDeactivationState() internal {
+    function _logVetoSignallingDeactivationState() internal view {
         /* solhint-disable no-console */
         (bool isActive, uint256 duration, uint256 enteredAt) = _getVetoSignallingDeactivationState();
 
@@ -525,7 +518,7 @@ contract ScenarioTestBlueprint is TestingAssertEqExtender, SetupDeployment {
     // Utils Methods
     // ---
 
-    function _step(string memory text) internal {
+    function _step(string memory text) internal view {
         // solhint-disable-next-line
         console.log(string.concat(">>> ", text, " <<<"));
     }
@@ -576,7 +569,7 @@ contract ScenarioTestBlueprint is TestingAssertEqExtender, SetupDeployment {
         uint256 _seconds;
     }
 
-    function _toDuration(uint256 timestamp) internal view returns (DurationStruct memory duration) {
+    function _toDuration(uint256 timestamp) internal pure returns (DurationStruct memory duration) {
         duration._days = timestamp / 1 days;
         duration._hours = (timestamp - 1 days * duration._days) / 1 hours;
         duration._minutes = (timestamp - 1 days * duration._days - 1 hours * duration._hours) / 1 minutes;


### PR DESCRIPTION
All problems with solc warnings were fixed except one: 

> function now() internal view returns (Timestamp res)
> _This declaration shadows a builtin symbol.solidity (2319)_

In previous versions of Solidity there was `block.now()` method so `Timestamp.now()` seems to shadow overrides it. There is no possible solution to drown that warning so possible solutions:
1. leave it as is;
2. change `now` to something like `current`.