### PR TITLE
Audit Fix: Add `EmergencyProtectedTimelock.MIN_EXECUTION_DELAY()` sanity check

### DIFF
--- a/contracts/EmergencyProtectedTimelock.sol
+++ b/contracts/EmergencyProtectedTimelock.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.26;
 
-import {Duration} from "./types/Duration.sol";
 import {Timestamp} from "./types/Timestamp.sol";
+import {Duration, Durations} from "./types/Duration.sol";
 
 import {IOwnable} from "./interfaces/IOwnable.sol";
 import {IEmergencyProtectedTimelock} from "./interfaces/IEmergencyProtectedTimelock.sol";
@@ -32,16 +32,22 @@ contract EmergencyProtectedTimelock is IEmergencyProtectedTimelock {
     // ---
 
     /// @notice The parameters for the sanity checks.
+    /// @param minExecutionDelay The minimum allowable duration for the combined after-submit and after-schedule delays.
     /// @param maxAfterSubmitDelay The maximum allowable delay before a submitted proposal can be scheduled for execution.
     /// @param maxAfterScheduleDelay The maximum allowable delay before a scheduled proposal can be executed.
     /// @param maxEmergencyModeDuration The maximum time the timelock can remain in emergency mode.
     /// @param maxEmergencyProtectionDuration The maximum time the emergency protection mechanism can be activated.
     struct SanityCheckParams {
+        Duration minExecutionDelay;
         Duration maxAfterSubmitDelay;
         Duration maxAfterScheduleDelay;
         Duration maxEmergencyModeDuration;
         Duration maxEmergencyProtectionDuration;
     }
+
+    /// @notice Represents the minimum allowed time that must pass between the submission of a proposal and its execution.
+    /// @dev The minimum permissible value for the sum of `afterScheduleDelay` and `afterSubmitDelay`.
+    Duration public immutable MIN_EXECUTION_DELAY;
 
     /// @notice The upper bound for the delay required before a submitted proposal can be scheduled for execution.
     Duration public immutable MAX_AFTER_SUBMIT_DELAY;
@@ -79,13 +85,29 @@ contract EmergencyProtectedTimelock is IEmergencyProtectedTimelock {
     // Constructor
     // ---
 
-    constructor(SanityCheckParams memory sanityCheckParams, address adminExecutor) {
+    constructor(
+        SanityCheckParams memory sanityCheckParams,
+        address adminExecutor,
+        Duration afterSubmitDelay,
+        Duration afterScheduleDelay
+    ) {
         _ADMIN_EXECUTOR = adminExecutor;
 
+        MIN_EXECUTION_DELAY = sanityCheckParams.minExecutionDelay;
         MAX_AFTER_SUBMIT_DELAY = sanityCheckParams.maxAfterSubmitDelay;
         MAX_AFTER_SCHEDULE_DELAY = sanityCheckParams.maxAfterScheduleDelay;
         MAX_EMERGENCY_MODE_DURATION = sanityCheckParams.maxEmergencyModeDuration;
         MAX_EMERGENCY_PROTECTION_DURATION = sanityCheckParams.maxEmergencyProtectionDuration;
+
+        if (afterSubmitDelay > Durations.ZERO) {
+            _timelockState.setAfterSubmitDelay(afterSubmitDelay, MAX_AFTER_SUBMIT_DELAY);
+        }
+
+        if (afterScheduleDelay > Durations.ZERO) {
+            _timelockState.setAfterScheduleDelay(afterScheduleDelay, MAX_AFTER_SCHEDULE_DELAY);
+        }
+
+        _timelockState.checkExecutionDelay(MIN_EXECUTION_DELAY);
     }
 
     // ---
@@ -139,13 +161,22 @@ contract EmergencyProtectedTimelock is IEmergencyProtectedTimelock {
         _timelockState.setGovernance(newGovernance);
     }
 
-    /// @notice Configures the delays for submitting and scheduling proposals, within defined upper bounds.
-    /// @param afterSubmitDelay The delay required before a submitted proposal can be scheduled.
-    /// @param afterScheduleDelay The delay required before a scheduled proposal can be executed.
-    function setupDelays(Duration afterSubmitDelay, Duration afterScheduleDelay) external {
+    /// @notice Sets the delay required to pass from the submission of a proposal before it can be scheduled for execution.
+    ///     Ensures that the new delay value complies with the defined sanity check bounds.
+    /// @param newAfterSubmitDelay The delay required before a submitted proposal can be scheduled.
+    function setAfterSubmitDelay(Duration newAfterSubmitDelay) external {
         _checkCallerIsAdminExecutor();
-        _timelockState.setAfterSubmitDelay(afterSubmitDelay, MAX_AFTER_SUBMIT_DELAY);
-        _timelockState.setAfterScheduleDelay(afterScheduleDelay, MAX_AFTER_SCHEDULE_DELAY);
+        _timelockState.setAfterSubmitDelay(newAfterSubmitDelay, MAX_AFTER_SUBMIT_DELAY);
+        _timelockState.checkExecutionDelay(MIN_EXECUTION_DELAY);
+    }
+
+    /// @notice Sets the delay required to pass from the scheduling of a proposal before it can be executed.
+    ///     Ensures that the new delay value complies with the defined sanity check bounds.
+    /// @param newAfterScheduleDelay The delay required before a scheduled proposal can be executed.
+    function setAfterScheduleDelay(Duration newAfterScheduleDelay) external {
+        _checkCallerIsAdminExecutor();
+        _timelockState.setAfterScheduleDelay(newAfterScheduleDelay, MAX_AFTER_SCHEDULE_DELAY);
+        _timelockState.checkExecutionDelay(MIN_EXECUTION_DELAY);
     }
 
     /// @notice Transfers ownership of the executor contract to a new owner.

--- a/contracts/libraries/TimelockState.sol
+++ b/contracts/libraries/TimelockState.sol
@@ -11,9 +11,10 @@ library TimelockState {
     // ---
 
     error CallerIsNotGovernance(address caller);
-    error InvalidGovernance(address value);
-    error InvalidAfterSubmitDelay(Duration value);
-    error InvalidAfterScheduleDelay(Duration value);
+    error InvalidGovernance(address governance);
+    error InvalidExecutionDelay(Duration executionDelay);
+    error InvalidAfterSubmitDelay(Duration afterSubmitDelay);
+    error InvalidAfterScheduleDelay(Duration afterScheduleDelay);
 
     // ---
     // Events
@@ -104,6 +105,16 @@ library TimelockState {
     function checkCallerIsGovernance(Context storage self) internal view {
         if (self.governance != msg.sender) {
             revert CallerIsNotGovernance(msg.sender);
+        }
+    }
+
+    /// @notice Checks that the combined after-submit and after-schedule delays meet the minimum required execution delay.
+    /// @param self The context of the Timelock State library library.
+    /// @param minExecutionDelay The minimum required delay between proposal submission and execution.
+    function checkExecutionDelay(Context storage self, Duration minExecutionDelay) internal view {
+        Duration executionDelay = self.afterScheduleDelay + self.afterSubmitDelay;
+        if (executionDelay < minExecutionDelay) {
+            revert InvalidExecutionDelay(executionDelay);
         }
     }
 }

--- a/docs/plan-b.md
+++ b/docs/plan-b.md
@@ -200,7 +200,7 @@ Resets the `governance` address to the `EMERGENCY_GOVERNANCE` value defined in t
 * MUST be called by the Emergency Execution Committee address.
 
 ### Admin functions
-The contract has the interface for managing the configuration related to emergency protection (`setEmergencyProtectionActivationCommittee`, `setEmergencyProtectionExecutionCommittee`, `setEmergencyProtectionEndDate`, `setEmergencyModeDuration`, `setEmergencyGovernance`) and general system wiring (`transferExecutorOwnership`, `setGovernance`, `setupDelays`). These functions MUST be called by the [Admin Executor](#) address.
+The contract has the interface for managing the configuration related to emergency protection (`setEmergencyProtectionActivationCommittee`, `setEmergencyProtectionExecutionCommittee`, `setEmergencyProtectionEndDate`, `setEmergencyModeDuration`, `setEmergencyGovernance`) and general system wiring (`transferExecutorOwnership`, `setGovernance`, `setAfterSubmitDelay`, `setAfterScheduleDelay`). These functions MUST be called by the [Admin Executor](#) address.
 
 ## Contract: `Executor`
 Executes calls resulting from governance proposals' execution. Every protocol permission or role protected by the TG, as well as the permission to manage these roles/permissions, should be assigned exclusively to instances of this contract.

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -1036,7 +1036,7 @@ Resets the `governance` address to the `EMERGENCY_GOVERNANCE` value defined in t
 
 ### Admin functions
 
-The contract has the interface for managing the configuration related to emergency protection (`setEmergencyProtectionActivationCommittee`, `setEmergencyProtectionExecutionCommittee`, `setEmergencyProtectionEndDate`, `setEmergencyModeDuration`, `setEmergencyGovernance`) and general system wiring (`transferExecutorOwnership`, `setGovernance`, `setupDelays`). These functions MUST be called by the [Admin Executor](#Administrative-actions) address, basically routing any such changes through the Dual Governance mechanics.
+The contract has the interface for managing the configuration related to emergency protection (`setEmergencyProtectionActivationCommittee`, `setEmergencyProtectionExecutionCommittee`, `setEmergencyProtectionEndDate`, `setEmergencyModeDuration`, `setEmergencyGovernance`) and general system wiring (`transferExecutorOwnership`, `setGovernance`, `setAfterSubmitDelay`, `setAfterScheduleDelay`). These functions MUST be called by the [Admin Executor](#Administrative-actions) address, basically routing any such changes through the Dual Governance mechanics.
 
 ## Contract: ImmutableDualGovernanceConfigProvider.sol
 

--- a/test/unit/EmergencyProtectedTimelock.t.sol
+++ b/test/unit/EmergencyProtectedTimelock.t.sol
@@ -4,7 +4,7 @@ pragma solidity 0.8.26;
 import {Vm} from "forge-std/Test.sol";
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 
-import {Duration, Durations} from "contracts/types/Duration.sol";
+import {Duration, Durations, MAX_DURATION_VALUE} from "contracts/types/Duration.sol";
 import {Timestamp, Timestamps} from "contracts/types/Timestamp.sol";
 
 import {IEmergencyProtectedTimelock} from "contracts/interfaces/IEmergencyProtectedTimelock.sol";
@@ -35,6 +35,17 @@ contract EmergencyProtectedTimelockUnitTests is UnitTest {
     address private _dualGovernance = makeAddr("DUAL_GOVERNANCE");
     address private _adminExecutor;
 
+    EmergencyProtectedTimelock.SanityCheckParams private _defaultSanityCheckParams = EmergencyProtectedTimelock
+        .SanityCheckParams({
+        minExecutionDelay: Durations.from(1 days),
+        maxAfterSubmitDelay: Durations.from(14 days),
+        maxAfterScheduleDelay: Durations.from(7 days),
+        maxEmergencyModeDuration: Durations.from(365 days),
+        maxEmergencyProtectionDuration: Durations.from(365 days)
+    });
+    Duration private _defaultAfterSubmitDelay = Durations.from(3 days);
+    Duration private _defaultAfterScheduleDelay = Durations.from(2 days);
+
     function setUp() external {
         _executor = new Executor(address(this));
         _adminExecutor = address(_executor);
@@ -48,7 +59,6 @@ contract EmergencyProtectedTimelockUnitTests is UnitTest {
 
         vm.startPrank(_adminExecutor);
         _timelock.setGovernance(_dualGovernance);
-        _timelock.setupDelays({afterSubmitDelay: Durations.from(3 days), afterScheduleDelay: Durations.from(2 days)});
         _timelock.setEmergencyProtectionActivationCommittee(_emergencyActivator);
         _timelock.setEmergencyProtectionExecutionCommittee(_emergencyEnactor);
         _timelock.setEmergencyProtectionEndDate(_emergencyProtectionDuration.addTo(Timestamps.now()));
@@ -59,18 +69,106 @@ contract EmergencyProtectedTimelockUnitTests is UnitTest {
 
     // EmergencyProtectedTimelock.constructor()
 
+    function test_constructor_HappyPath_NonZeroDelays() external {
+        EmergencyProtectedTimelock.SanityCheckParams memory sanityCheckParams = _defaultSanityCheckParams;
+
+        address adminExecutor = makeAddr("ADMIN_EXECUTOR");
+        Duration afterSubmitDelay = _defaultAfterSubmitDelay;
+        Duration afterScheduleDelay = _defaultAfterScheduleDelay;
+
+        vm.expectEmit();
+        emit TimelockState.AfterSubmitDelaySet(afterSubmitDelay);
+
+        vm.expectEmit();
+        emit TimelockState.AfterScheduleDelaySet(afterScheduleDelay);
+
+        EmergencyProtectedTimelock timelock =
+            new EmergencyProtectedTimelock(sanityCheckParams, adminExecutor, afterSubmitDelay, afterScheduleDelay);
+
+        _assertEmergencyProtectedTimelockConstructorParams(
+            timelock, sanityCheckParams, adminExecutor, afterSubmitDelay, afterScheduleDelay
+        );
+    }
+
+    function test_constructor_HappyPath_ZeroDelays() external {
+        EmergencyProtectedTimelock.SanityCheckParams memory sanityCheckParams = _defaultSanityCheckParams;
+        sanityCheckParams.minExecutionDelay = Durations.ZERO;
+
+        address adminExecutor = makeAddr("ADMIN_EXECUTOR");
+        Duration afterSubmitDelay = Durations.ZERO;
+        Duration afterScheduleDelay = Durations.ZERO;
+
+        vm.recordLogs();
+
+        EmergencyProtectedTimelock timelock =
+            new EmergencyProtectedTimelock(sanityCheckParams, adminExecutor, afterSubmitDelay, afterScheduleDelay);
+
+        assertEq(vm.getRecordedLogs().length, 0);
+
+        _assertEmergencyProtectedTimelockConstructorParams(
+            timelock, sanityCheckParams, adminExecutor, afterSubmitDelay, afterScheduleDelay
+        );
+    }
+
+    function test_constructor_RevertOn_AfterSubmitDelayExceeded() external {
+        EmergencyProtectedTimelock.SanityCheckParams memory sanityCheckParams = _defaultSanityCheckParams;
+
+        address adminExecutor = makeAddr("ADMIN_EXECUTOR");
+        Duration afterSubmitDelay = sanityCheckParams.maxAfterSubmitDelay + Durations.from(1 seconds);
+        Duration afterScheduleDelay = sanityCheckParams.maxAfterScheduleDelay;
+
+        vm.expectRevert(abi.encodeWithSelector(TimelockState.InvalidAfterSubmitDelay.selector, afterSubmitDelay));
+
+        EmergencyProtectedTimelock timelock =
+            new EmergencyProtectedTimelock(sanityCheckParams, adminExecutor, afterSubmitDelay, afterScheduleDelay);
+    }
+
+    function test_constructor_RevertOn_AfterScheduleDelayExceeded() external {
+        EmergencyProtectedTimelock.SanityCheckParams memory sanityCheckParams = _defaultSanityCheckParams;
+
+        address adminExecutor = makeAddr("ADMIN_EXECUTOR");
+        Duration afterSubmitDelay = sanityCheckParams.maxAfterSubmitDelay;
+        Duration afterScheduleDelay = sanityCheckParams.maxAfterScheduleDelay + Durations.from(1 seconds);
+
+        vm.expectRevert(abi.encodeWithSelector(TimelockState.InvalidAfterScheduleDelay.selector, afterScheduleDelay));
+
+        EmergencyProtectedTimelock timelock =
+            new EmergencyProtectedTimelock(sanityCheckParams, adminExecutor, afterSubmitDelay, afterScheduleDelay);
+    }
+
+    function test_constructor_RevertOn_MinExecutionDelayTooLow() external {
+        EmergencyProtectedTimelock.SanityCheckParams memory sanityCheckParams = _defaultSanityCheckParams;
+        sanityCheckParams.minExecutionDelay = Durations.from(MAX_DURATION_VALUE);
+
+        address adminExecutor = makeAddr("ADMIN_EXECUTOR");
+        Duration afterSubmitDelay = _defaultAfterSubmitDelay;
+        Duration afterScheduleDelay = _defaultAfterScheduleDelay;
+
+        vm.expectRevert(
+            abi.encodeWithSelector(TimelockState.InvalidExecutionDelay.selector, afterSubmitDelay + afterScheduleDelay)
+        );
+
+        EmergencyProtectedTimelock timelock =
+            new EmergencyProtectedTimelock(sanityCheckParams, adminExecutor, afterSubmitDelay, afterScheduleDelay);
+    }
+
     function testFuzz_constructor_HappyPath(
         EmergencyProtectedTimelock.SanityCheckParams memory sanityCheckParams,
-        address adminExecutor
+        address adminExecutor,
+        Duration afterSubmitDelay,
+        Duration afterScheduleDelay
     ) external {
-        EmergencyProtectedTimelock timelock = new EmergencyProtectedTimelock(sanityCheckParams, adminExecutor);
+        vm.assume(afterSubmitDelay <= sanityCheckParams.maxAfterSubmitDelay);
+        vm.assume(afterScheduleDelay <= sanityCheckParams.maxAfterScheduleDelay);
+        vm.assume(afterSubmitDelay.toSeconds() + afterScheduleDelay.toSeconds() <= MAX_DURATION_VALUE);
+        vm.assume(afterSubmitDelay + afterScheduleDelay >= sanityCheckParams.minExecutionDelay);
 
-        assertEq(timelock.getAdminExecutor(), adminExecutor);
+        EmergencyProtectedTimelock timelock =
+            new EmergencyProtectedTimelock(sanityCheckParams, adminExecutor, afterSubmitDelay, afterScheduleDelay);
 
-        assertEq(timelock.MAX_AFTER_SUBMIT_DELAY(), sanityCheckParams.maxAfterSubmitDelay);
-        assertEq(timelock.MAX_AFTER_SCHEDULE_DELAY(), sanityCheckParams.maxAfterScheduleDelay);
-        assertEq(timelock.MAX_EMERGENCY_MODE_DURATION(), sanityCheckParams.maxEmergencyModeDuration);
-        assertEq(timelock.MAX_EMERGENCY_PROTECTION_DURATION(), sanityCheckParams.maxEmergencyProtectionDuration);
+        _assertEmergencyProtectedTimelockConstructorParams(
+            timelock, sanityCheckParams, adminExecutor, afterSubmitDelay, afterScheduleDelay
+        );
     }
 
     // EmergencyProtectedTimelock.submit()
@@ -212,29 +310,132 @@ contract EmergencyProtectedTimelockUnitTests is UnitTest {
         _timelock.cancelAllNonExecutedProposals();
     }
 
-    function testFuzz_setupDelays_HappyPath(Duration afterSubmitDelay, Duration afterScheduleDelay) external {
-        vm.assume(
-            afterSubmitDelay != _timelock.getAfterSubmitDelay() && afterSubmitDelay < _timelock.MAX_AFTER_SUBMIT_DELAY()
-        );
-        vm.assume(
-            afterScheduleDelay != _timelock.getAfterScheduleDelay()
-                && afterScheduleDelay < _timelock.MAX_AFTER_SCHEDULE_DELAY()
+    // EmergencyProtectedTimelock.setAfterSubmitDelay()
+
+    function test_setAfterSubmitDelay_HappyPath() external {
+        Duration newAfterSubmitDelay = _timelock.getAfterSubmitDelay() + Durations.from(1 seconds);
+
+        vm.expectEmit();
+        emit TimelockState.AfterSubmitDelaySet(newAfterSubmitDelay);
+
+        vm.prank(_adminExecutor);
+        _timelock.setAfterSubmitDelay(newAfterSubmitDelay);
+
+        assertEq(_timelock.getAfterSubmitDelay(), newAfterSubmitDelay);
+    }
+
+    function test_setAfterSubmitDelay_RevertOn_MaxAfterSubmitDelayExceeded() external {
+        Duration newAfterSubmitDelay = _defaultSanityCheckParams.maxAfterSubmitDelay + Durations.from(1 seconds);
+
+        vm.expectRevert(abi.encodeWithSelector(TimelockState.InvalidAfterSubmitDelay.selector, newAfterSubmitDelay));
+
+        vm.prank(_adminExecutor);
+        _timelock.setAfterSubmitDelay(newAfterSubmitDelay);
+    }
+
+    function test_setAfterSubmitDelay_RevertOn_ExecutionDelayTooLow() external {
+        vm.prank(_adminExecutor);
+        _timelock.setAfterScheduleDelay(Durations.ZERO);
+
+        Duration afterScheduleDelay = _timelock.getAfterScheduleDelay();
+        assertEq(afterScheduleDelay, Durations.ZERO);
+
+        Duration newAfterSubmitDelay = _defaultSanityCheckParams.minExecutionDelay.dividedBy(2);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                TimelockState.InvalidExecutionDelay.selector, newAfterSubmitDelay + afterScheduleDelay
+            )
         );
 
         vm.prank(_adminExecutor);
-        _timelock.setupDelays({afterSubmitDelay: afterSubmitDelay, afterScheduleDelay: afterScheduleDelay});
-
-        assertEq(_timelock.getAfterSubmitDelay(), afterSubmitDelay);
-        assertEq(_timelock.getAfterScheduleDelay(), afterScheduleDelay);
+        _timelock.setAfterSubmitDelay(newAfterSubmitDelay);
     }
 
-    function test_setupDelays_RevertOn_ByStranger(address stranger) external {
-        vm.assume(stranger != _adminExecutor);
-        vm.assume(stranger != address(0));
+    function test_setAfterSubmitDelay_RevertOn_CalledNotByAdminExecutor() external {
+        Duration newAfterSubmitDelay = _defaultSanityCheckParams.maxAfterSubmitDelay + Durations.from(1 seconds);
 
-        vm.prank(stranger);
-        vm.expectRevert(abi.encodeWithSelector(EmergencyProtectedTimelock.CallerIsNotAdminExecutor.selector, stranger));
-        _timelock.setupDelays({afterSubmitDelay: Durations.from(1 days), afterScheduleDelay: Durations.from(1 days)});
+        vm.expectRevert(
+            abi.encodeWithSelector(EmergencyProtectedTimelock.CallerIsNotAdminExecutor.selector, address(this))
+        );
+        _timelock.setAfterSubmitDelay(newAfterSubmitDelay);
+    }
+
+    function testFuzz_setAfterSubmitDelay_HappyPath(Duration newAfterSubmitDelay) external {
+        vm.assume(newAfterSubmitDelay <= _defaultSanityCheckParams.maxAfterSubmitDelay);
+        vm.assume(
+            _timelock.getAfterScheduleDelay() + newAfterSubmitDelay >= _defaultSanityCheckParams.minExecutionDelay
+        );
+        vm.assume(_timelock.getAfterSubmitDelay() != newAfterSubmitDelay);
+
+        vm.prank(_adminExecutor);
+        _timelock.setAfterSubmitDelay(newAfterSubmitDelay);
+
+        assertEq(_timelock.getAfterSubmitDelay(), newAfterSubmitDelay);
+    }
+
+    // EmergencyProtectedTimelock.setAfterScheduleDelay()
+
+    function test_setAfterScheduleDelay_HappyPath() external {
+        Duration newAfterScheduleDelay = _timelock.getAfterScheduleDelay() + Durations.from(1 seconds);
+
+        vm.expectEmit();
+        emit TimelockState.AfterScheduleDelaySet(newAfterScheduleDelay);
+
+        vm.prank(_adminExecutor);
+        _timelock.setAfterScheduleDelay(newAfterScheduleDelay);
+
+        assertEq(_timelock.getAfterScheduleDelay(), newAfterScheduleDelay);
+    }
+
+    function test_setAfterScheduleDelay_RevertOn_MaxAfterScheduleDelayExceeded() external {
+        Duration newAfterScheduleDelay = _defaultSanityCheckParams.maxAfterScheduleDelay + Durations.from(1 seconds);
+
+        vm.expectRevert(abi.encodeWithSelector(TimelockState.InvalidAfterScheduleDelay.selector, newAfterScheduleDelay));
+
+        vm.prank(_adminExecutor);
+        _timelock.setAfterScheduleDelay(newAfterScheduleDelay);
+    }
+
+    function test_setAfterScheduleDelay_RevertOn_ExecutionDelayTooLow() external {
+        vm.prank(_adminExecutor);
+        _timelock.setAfterSubmitDelay(Durations.ZERO);
+
+        Duration afterSubmitDelay = _timelock.getAfterSubmitDelay();
+        assertEq(afterSubmitDelay, Durations.ZERO);
+
+        Duration newAfterScheduleDelay = _defaultSanityCheckParams.minExecutionDelay.dividedBy(2);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                TimelockState.InvalidExecutionDelay.selector, newAfterScheduleDelay + afterSubmitDelay
+            )
+        );
+
+        vm.prank(_adminExecutor);
+        _timelock.setAfterScheduleDelay(newAfterScheduleDelay);
+    }
+
+    function test_setAfterScheduleDelay_RevertOn_CalledNotByAdminExecutor() external {
+        Duration newAfterScheduleDelay = _defaultSanityCheckParams.maxAfterScheduleDelay + Durations.from(1 seconds);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(EmergencyProtectedTimelock.CallerIsNotAdminExecutor.selector, address(this))
+        );
+        _timelock.setAfterScheduleDelay(newAfterScheduleDelay);
+    }
+
+    function testFuzz_setAfterScheduleDelay_HappyPath(Duration newAfterScheduleDelay) external {
+        vm.assume(newAfterScheduleDelay <= _defaultSanityCheckParams.maxAfterScheduleDelay);
+        vm.assume(
+            _timelock.getAfterScheduleDelay() + newAfterScheduleDelay >= _defaultSanityCheckParams.minExecutionDelay
+        );
+        vm.assume(_timelock.getAfterScheduleDelay() != newAfterScheduleDelay);
+
+        vm.prank(_adminExecutor);
+        _timelock.setAfterScheduleDelay(newAfterScheduleDelay);
+
+        assertEq(_timelock.getAfterScheduleDelay(), newAfterScheduleDelay);
     }
 
     // EmergencyProtectedTimelock.transferExecutorOwnership()
@@ -989,14 +1190,20 @@ contract EmergencyProtectedTimelockUnitTests is UnitTest {
     }
 
     function testFuzz_getAdminExecutor(address executor) external {
+        Duration afterSubmitDelay = Durations.from(3 days);
+        Duration afterScheduleDelay = Durations.from(1 days);
+
         EmergencyProtectedTimelock timelock = new EmergencyProtectedTimelock(
             EmergencyProtectedTimelock.SanityCheckParams({
+                minExecutionDelay: Durations.from(0 seconds),
                 maxAfterSubmitDelay: Durations.from(45 days),
                 maxAfterScheduleDelay: Durations.from(45 days),
                 maxEmergencyModeDuration: Durations.from(365 days),
                 maxEmergencyProtectionDuration: Durations.from(365 days)
             }),
-            executor
+            executor,
+            afterSubmitDelay,
+            afterScheduleDelay
         );
 
         assertEq(timelock.getAdminExecutor(), executor);
@@ -1032,13 +1239,45 @@ contract EmergencyProtectedTimelockUnitTests is UnitTest {
 
     function _deployEmergencyProtectedTimelock() internal returns (EmergencyProtectedTimelock) {
         return new EmergencyProtectedTimelock(
-            EmergencyProtectedTimelock.SanityCheckParams({
-                maxAfterSubmitDelay: Durations.from(45 days),
-                maxAfterScheduleDelay: Durations.from(45 days),
-                maxEmergencyModeDuration: Durations.from(365 days),
-                maxEmergencyProtectionDuration: Durations.from(365 days)
-            }),
-            _adminExecutor
+            _defaultSanityCheckParams, _adminExecutor, _defaultAfterSubmitDelay, _defaultAfterScheduleDelay
+        );
+    }
+
+    function _assertEmergencyProtectedTimelockConstructorParams(
+        EmergencyProtectedTimelock timelock,
+        EmergencyProtectedTimelock.SanityCheckParams memory sanityCheckParams,
+        address adminExecutor,
+        Duration afterSubmitDelay,
+        Duration afterScheduleDelay
+    ) internal {
+        assertEq(timelock.getAdminExecutor(), adminExecutor, "Unexpected 'adminExecutor' value");
+        assertEq(timelock.getAfterSubmitDelay(), afterSubmitDelay, "Unexpected 'afterSubmitDelay' value");
+        assertEq(timelock.getAfterScheduleDelay(), afterScheduleDelay, "Unexpected 'afterScheduleDelay' value");
+
+        assertEq(
+            timelock.MIN_EXECUTION_DELAY(),
+            sanityCheckParams.minExecutionDelay,
+            "Unexpected 'MIN_EXECUTION_DELAY' value"
+        );
+        assertEq(
+            timelock.MAX_AFTER_SUBMIT_DELAY(),
+            sanityCheckParams.maxAfterSubmitDelay,
+            "Unexpected 'MAX_AFTER_SUBMIT_DELAY' value"
+        );
+        assertEq(
+            timelock.MAX_AFTER_SCHEDULE_DELAY(),
+            sanityCheckParams.maxAfterScheduleDelay,
+            "Unexpected 'MAX_AFTER_SCHEDULE_DELAY' value"
+        );
+        assertEq(
+            timelock.MAX_EMERGENCY_MODE_DURATION(),
+            sanityCheckParams.maxEmergencyModeDuration,
+            "Unexpected 'MAX_EMERGENCY_MODE_DURATION' value"
+        );
+        assertEq(
+            timelock.MAX_EMERGENCY_PROTECTION_DURATION(),
+            sanityCheckParams.maxEmergencyProtectionDuration,
+            "Unexpected 'MAX_EMERGENCY_PROTECTION_DURATION' value"
         );
     }
 }

--- a/test/unit/libraries/TimelockState.t.sol
+++ b/test/unit/libraries/TimelockState.t.sol
@@ -2,7 +2,7 @@
 pragma solidity 0.8.26;
 
 import {TimelockState} from "contracts/libraries/TimelockState.sol";
-import {Duration, Durations} from "contracts/types/Duration.sol";
+import {Duration, Durations, MAX_DURATION_VALUE, DurationOverflow} from "contracts/types/Duration.sol";
 
 import {UnitTest} from "test/utils/unit-test.sol";
 
@@ -109,7 +109,134 @@ contract TimelockStateUnitTests is UnitTest {
         this.external__checkCallerIsGovernance();
     }
 
+    // ---
+    // checkExecutionDelay()
+    // ---
+
+    function test_checkExecutionDelay_HappyPath_Positive() external {
+        assertTrue(_timelockState.afterSubmitDelay > Durations.ZERO);
+        assertTrue(_timelockState.afterScheduleDelay > Durations.ZERO);
+
+        // regular case
+        Duration minExecutionDelay = (_timelockState.afterSubmitDelay + _timelockState.afterScheduleDelay).dividedBy(2);
+        this.external__checkExecutionDelay(minExecutionDelay);
+
+        // edge case, when minExecutionDelay equal to sum of after submit and after schedule delays
+        minExecutionDelay = _timelockState.afterSubmitDelay + _timelockState.afterScheduleDelay;
+        this.external__checkExecutionDelay(minExecutionDelay);
+
+        // edge case, when minExecutionDelay is zero while after submit and after schedule is not
+        minExecutionDelay = Durations.ZERO;
+        this.external__checkExecutionDelay(minExecutionDelay);
+
+        // edge case, when minExecutionDelay, afterSubmitDelay and afterScheduleDelay is zero
+        minExecutionDelay = Durations.ZERO;
+        _timelockState.afterSubmitDelay = Durations.ZERO;
+        _timelockState.afterScheduleDelay = Durations.ZERO;
+        this.external__checkExecutionDelay(minExecutionDelay);
+
+        // edge case with MAX_DURATION_VALUE
+        minExecutionDelay = Durations.from(MAX_DURATION_VALUE);
+
+        _timelockState.afterSubmitDelay = Durations.ZERO;
+        _timelockState.afterScheduleDelay = Durations.from(MAX_DURATION_VALUE);
+        this.external__checkExecutionDelay(minExecutionDelay);
+
+        _timelockState.afterSubmitDelay = Durations.from(MAX_DURATION_VALUE);
+        _timelockState.afterScheduleDelay = Durations.ZERO;
+        this.external__checkExecutionDelay(minExecutionDelay);
+    }
+
+    function test_checkExecutionDelay_HappyPath_Negative() external {
+        assertTrue(_timelockState.afterSubmitDelay > Durations.ZERO);
+        assertTrue(_timelockState.afterScheduleDelay > Durations.ZERO);
+
+        // regular case
+        Duration minExecutionDelay =
+            _timelockState.afterSubmitDelay + _timelockState.afterScheduleDelay + Durations.from(1 seconds);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                TimelockState.InvalidExecutionDelay.selector,
+                _timelockState.afterSubmitDelay + _timelockState.afterScheduleDelay
+            )
+        );
+        this.external__checkExecutionDelay(minExecutionDelay);
+
+        // edge case afterSubmitDelay and afterScheduleDelay is zero while minExecutionDelay is not
+        minExecutionDelay = Durations.from(1 seconds);
+        _timelockState.afterSubmitDelay = Durations.ZERO;
+        _timelockState.afterScheduleDelay = Durations.ZERO;
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                TimelockState.InvalidExecutionDelay.selector,
+                _timelockState.afterSubmitDelay + _timelockState.afterScheduleDelay
+            )
+        );
+        this.external__checkExecutionDelay(minExecutionDelay);
+
+        // edge case afterSubmitDelay + afterScheduleDelay sum overflows Duration max value
+        minExecutionDelay = Durations.from(MAX_DURATION_VALUE);
+        _timelockState.afterSubmitDelay = Durations.from(1 seconds);
+        _timelockState.afterScheduleDelay = Durations.from(MAX_DURATION_VALUE);
+
+        vm.expectRevert(abi.encodeWithSelector(DurationOverflow.selector));
+        this.external__checkExecutionDelay(minExecutionDelay);
+    }
+
+    function testFuzz_checkExecutionDelay_Positive(
+        Duration minExecutionDelay,
+        Duration afterSubmitDelay,
+        Duration afterScheduleDelay
+    ) external {
+        vm.assume(afterSubmitDelay.toSeconds() + afterScheduleDelay.toSeconds() <= MAX_DURATION_VALUE);
+        vm.assume(minExecutionDelay <= afterSubmitDelay + afterScheduleDelay);
+
+        _timelockState.afterSubmitDelay = afterSubmitDelay;
+        _timelockState.afterScheduleDelay = afterScheduleDelay;
+        this.external__checkExecutionDelay(minExecutionDelay);
+    }
+
+    function testFuzz_checkExecutionDelay_Negative(
+        Duration minExecutionDelay,
+        Duration afterSubmitDelay,
+        Duration afterScheduleDelay
+    ) external {
+        vm.assume(afterSubmitDelay.toSeconds() + afterScheduleDelay.toSeconds() <= MAX_DURATION_VALUE);
+        vm.assume(minExecutionDelay > afterSubmitDelay + afterScheduleDelay);
+
+        _timelockState.afterSubmitDelay = afterSubmitDelay;
+        _timelockState.afterScheduleDelay = afterScheduleDelay;
+
+        vm.expectRevert(
+            abi.encodeWithSelector(TimelockState.InvalidExecutionDelay.selector, afterSubmitDelay + afterScheduleDelay)
+        );
+        this.external__checkExecutionDelay(minExecutionDelay);
+    }
+
+    function testFuzz_checkExecutionDelay_DurationOverflow(
+        Duration minExecutionDelay,
+        Duration afterSubmitDelay,
+        Duration afterScheduleDelay
+    ) external {
+        vm.assume(afterSubmitDelay.toSeconds() + afterScheduleDelay.toSeconds() > MAX_DURATION_VALUE);
+
+        _timelockState.afterSubmitDelay = afterSubmitDelay;
+        _timelockState.afterScheduleDelay = afterScheduleDelay;
+
+        vm.expectRevert(abi.encodeWithSelector(DurationOverflow.selector));
+        this.external__checkExecutionDelay(minExecutionDelay);
+    }
+
+    // ---
+    // Helper Methods
+    // ---
+
     function external__checkCallerIsGovernance() external {
         TimelockState.checkCallerIsGovernance(_timelockState);
+    }
+
+    function external__checkExecutionDelay(Duration minExecutionDelay) external {
+        _timelockState.checkExecutionDelay(minExecutionDelay);
     }
 }

--- a/test/utils/SetupDeployment.sol
+++ b/test/utils/SetupDeployment.sol
@@ -68,6 +68,7 @@ abstract contract SetupDeployment is Test {
     // Emergency Protected Timelock Deployment Parameters
     // ---
 
+    Duration internal immutable _MIN_EXECUTION_DELAY = Durations.from(0 seconds);
     Duration internal immutable _AFTER_SUBMIT_DELAY = Durations.from(3 days);
     Duration internal immutable _MAX_AFTER_SUBMIT_DELAY = Durations.from(45 days);
 
@@ -288,9 +289,6 @@ abstract contract SetupDeployment is Test {
     }
 
     function _finalizeEmergencyProtectedTimelockDeploy(IGovernance governance) internal {
-        _adminExecutor.execute(
-            address(_timelock), 0, abi.encodeCall(_timelock.setupDelays, (_AFTER_SUBMIT_DELAY, _AFTER_SCHEDULE_DELAY))
-        );
         _adminExecutor.execute(address(_timelock), 0, abi.encodeCall(_timelock.setGovernance, (address(governance))));
         _adminExecutor.transferOwnership(address(_timelock));
     }
@@ -303,11 +301,14 @@ abstract contract SetupDeployment is Test {
         return new EmergencyProtectedTimelock({
             adminExecutor: address(adminExecutor),
             sanityCheckParams: EmergencyProtectedTimelock.SanityCheckParams({
+                minExecutionDelay: _MIN_EXECUTION_DELAY,
                 maxAfterSubmitDelay: _MAX_AFTER_SUBMIT_DELAY,
                 maxAfterScheduleDelay: _MAX_AFTER_SCHEDULE_DELAY,
                 maxEmergencyModeDuration: _MAX_EMERGENCY_MODE_DURATION,
                 maxEmergencyProtectionDuration: _MAX_EMERGENCY_PROTECTION_DURATION
-            })
+            }),
+            afterSubmitDelay: _AFTER_SUBMIT_DELAY,
+            afterScheduleDelay: _AFTER_SCHEDULE_DELAY
         });
     }
 

--- a/test/utils/testing-assert-eq-extender.sol
+++ b/test/utils/testing-assert-eq-extender.sol
@@ -25,6 +25,10 @@ contract TestingAssertEqExtender is Test {
         assertEq(uint256(Duration.unwrap(a)), uint256(Duration.unwrap(b)));
     }
 
+    function assertEq(Duration a, Duration b, string memory message) internal {
+        assertEq(uint256(Duration.unwrap(a)), uint256(Duration.unwrap(b)), message);
+    }
+
     function assertEq(Timestamp a, Timestamp b) internal {
         assertEq(uint256(Timestamp.unwrap(a)), uint256(Timestamp.unwrap(b)));
     }


### PR DESCRIPTION
The initial configuration of `afterSubmitDelay` and `afterScheduleDelay` has been moved to the constructor of the `EmergencyProtectedTimelock` contract, along with the introduction of the new sanity check parameter `MIN_EXECUTION_DELAY`. This ensures that the combined duration of `afterSubmitDelay` and `afterScheduleDelay` cannot fall below `MIN_EXECUTION_DELAY`. These changes are intended to reduce the risk of misconfiguration of the `EmergencyProtectedTimelock` during deployment and when updating delay values in the future.