### PR TITLE
DualGovernanceConfig additional constraints

### DIFF
--- a/contracts/libraries/DualGovernanceConfig.sol
+++ b/contracts/libraries/DualGovernanceConfig.sol
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.26;
 
-import {PercentD16} from "../types/PercentD16.sol";
+import {PercentD16, PercentsD16, HUNDRED_PERCENT_D16} from "../types/PercentD16.sol";
 import {Duration, Durations} from "../types/Duration.sol";
 import {Timestamp, Timestamps} from "../types/Timestamp.sol";
 
@@ -13,6 +13,7 @@ library DualGovernanceConfig {
     // Errors
     // ---
 
+    error InvalidSecondSealRageQuitSupport(PercentD16 secondSealRageQuitSupport);
     error InvalidRageQuitSupportRange(PercentD16 firstSealRageQuitSupport, PercentD16 secondSealRageQuitSupport);
     error InvalidRageQuitEthWithdrawalsDelayRange(
         Duration rageQuitEthWithdrawalsMinDelay, Duration rageQuitEthWithdrawalsMaxDelay
@@ -65,6 +66,12 @@ library DualGovernanceConfig {
     }
 
     // ---
+    // Constants
+    // ---
+
+    uint256 internal constant MAX_SECOND_SEAL_RAGE_QUIT_SUPPORT = HUNDRED_PERCENT_D16;
+
+    // ---
     // Main Functionality
     // ---
 
@@ -72,6 +79,10 @@ library DualGovernanceConfig {
     ///     of the Dual Governance system.
     /// @param self The configuration context.
     function validate(Context memory self) internal pure {
+        if (self.secondSealRageQuitSupport > PercentsD16.from(MAX_SECOND_SEAL_RAGE_QUIT_SUPPORT)) {
+            revert InvalidSecondSealRageQuitSupport(self.secondSealRageQuitSupport);
+        }
+
         if (self.firstSealRageQuitSupport >= self.secondSealRageQuitSupport) {
             revert InvalidRageQuitSupportRange(self.firstSealRageQuitSupport, self.secondSealRageQuitSupport);
         }
@@ -203,11 +214,11 @@ library DualGovernanceConfig {
         Context memory self,
         uint256 rageQuitRound
     ) internal pure returns (Duration) {
-        return Durations.min(
-            self.rageQuitEthWithdrawalsMinDelay.plusSeconds(
-                rageQuitRound * self.rageQuitEthWithdrawalsDelayGrowth.toSeconds()
-            ),
-            self.rageQuitEthWithdrawalsMaxDelay
-        );
+        uint256 rageQuitWithdrawalsDelayInSeconds = self.rageQuitEthWithdrawalsMinDelay.toSeconds()
+            + rageQuitRound * self.rageQuitEthWithdrawalsDelayGrowth.toSeconds();
+
+        return rageQuitWithdrawalsDelayInSeconds > self.rageQuitEthWithdrawalsMaxDelay.toSeconds()
+            ? self.rageQuitEthWithdrawalsMaxDelay
+            : Durations.from(rageQuitWithdrawalsDelayInSeconds);
     }
 }

--- a/contracts/types/Duration.sol
+++ b/contracts/types/Duration.sol
@@ -153,8 +153,4 @@ library Durations {
         ///     to `MAX_DURATION_VALUE`, which fits within the `uint32`.
         res = Duration.wrap(uint32(durationInSeconds));
     }
-
-    function min(Duration d1, Duration d2) internal pure returns (Duration res) {
-        res = d1 < d2 ? d1 : d2;
-    }
 }

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -329,6 +329,7 @@ Sets the configuration provider for the Dual Governance system.
 - The `newConfigProvider` address MUST NOT be the same as the current configuration provider.
 - The values returned by the config MUST be valid:
   - `firstSealRageQuitSupport` MUST be less than `secondSealRageQuitSupport`.
+  - `secondSealRageQuitSupport` MUST be less than or equal to 100%, represented as a percentage with 16 decimal places of precision.
   - `vetoSignallingMinDuration` MUST be less than `vetoSignallingMaxDuration`.
   - `rageQuitEthWithdrawalsMinDelay` MUST be less than or equal to `rageQuitEthWithdrawalsMaxDelay`.
   - `minAssetsLockDuration` MUST NOT be zero.

--- a/test/unit/libraries/DualGovernanceConfig.t.sol
+++ b/test/unit/libraries/DualGovernanceConfig.t.sol
@@ -13,7 +13,8 @@ contract DualGovernanceConfigTest is UnitTest {
 
     // Unrealistically huge value for the percents value, to limit max fuzz value to avoid overflow
     // due to very high values
-    PercentD16 internal immutable _SECOND_SEAL_RAGE_QUIT_SUPPORT_LIMIT = PercentsD16.fromBasisPoints(1_000_000_00);
+    PercentD16 internal immutable _MAX_SECOND_SEAL_RAGE_QUIT_SUPPORT =
+        PercentsD16.from(DualGovernanceConfig.MAX_SECOND_SEAL_RAGE_QUIT_SUPPORT);
     Timestamp internal immutable _MAX_TIMESTAMP = Timestamps.from(block.timestamp + 100 * 365 days);
 
     // The actual max value will not exceed 255, but for testing is used higher upper bound
@@ -40,12 +41,30 @@ contract DualGovernanceConfigTest is UnitTest {
 
     function testFuzz_validate_HappyPath(DualGovernanceConfig.Context memory config) external {
         _assumeConfigParams(config);
-        config.validate();
+        this.external__validate(config);
+    }
+
+    function testFuzz_validate_RevertOn_InvalidSecondSealRageQuitSupport(DualGovernanceConfig.Context memory config)
+        external
+    {
+        vm.assume(config.secondSealRageQuitSupport > _MAX_SECOND_SEAL_RAGE_QUIT_SUPPORT);
+        vm.assume(config.firstSealRageQuitSupport < config.secondSealRageQuitSupport);
+        vm.assume(config.vetoSignallingMinDuration < config.vetoSignallingMaxDuration);
+        vm.assume(config.rageQuitEthWithdrawalsMinDelay <= config.rageQuitEthWithdrawalsMaxDelay);
+        vm.assume(config.minAssetsLockDuration > Durations.ZERO);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                DualGovernanceConfig.InvalidSecondSealRageQuitSupport.selector, config.secondSealRageQuitSupport
+            )
+        );
+        this.external__validate(config);
     }
 
     function testFuzz_validate_RevertOn_InvalidSealRageQuitSupportRange(DualGovernanceConfig.Context memory config)
         external
     {
+        vm.assume(config.secondSealRageQuitSupport <= _MAX_SECOND_SEAL_RAGE_QUIT_SUPPORT);
         vm.assume(config.firstSealRageQuitSupport >= config.secondSealRageQuitSupport);
         vm.assume(config.vetoSignallingMinDuration < config.vetoSignallingMaxDuration);
         vm.assume(config.rageQuitEthWithdrawalsMinDelay <= config.rageQuitEthWithdrawalsMaxDelay);
@@ -57,14 +76,14 @@ contract DualGovernanceConfigTest is UnitTest {
                 config.secondSealRageQuitSupport
             )
         );
-        config.validate();
+        this.external__validate(config);
     }
 
     function testFuzz_validate_RevertOn_InvalidVetoSignallingDurationRange(DualGovernanceConfig.Context memory config)
         external
     {
         vm.assume(config.firstSealRageQuitSupport < config.secondSealRageQuitSupport);
-        vm.assume(config.secondSealRageQuitSupport < _SECOND_SEAL_RAGE_QUIT_SUPPORT_LIMIT);
+        vm.assume(config.secondSealRageQuitSupport < _MAX_SECOND_SEAL_RAGE_QUIT_SUPPORT);
         vm.assume(config.vetoSignallingMinDuration >= config.vetoSignallingMaxDuration);
         vm.assume(config.rageQuitEthWithdrawalsMinDelay <= config.rageQuitEthWithdrawalsMaxDelay);
 
@@ -75,14 +94,14 @@ contract DualGovernanceConfigTest is UnitTest {
                 config.vetoSignallingMaxDuration
             )
         );
-        config.validate();
+        this.external__validate(config);
     }
 
     function testFuzz_validate_RevertOn_InvalidRageQuitEthWithdrawalsDelayRange(
         DualGovernanceConfig.Context memory config
     ) external {
         vm.assume(config.firstSealRageQuitSupport < config.secondSealRageQuitSupport);
-        vm.assume(config.secondSealRageQuitSupport < _SECOND_SEAL_RAGE_QUIT_SUPPORT_LIMIT);
+        vm.assume(config.secondSealRageQuitSupport < _MAX_SECOND_SEAL_RAGE_QUIT_SUPPORT);
         vm.assume(config.vetoSignallingMinDuration < config.vetoSignallingMaxDuration);
         vm.assume(config.rageQuitEthWithdrawalsMinDelay > config.rageQuitEthWithdrawalsMaxDelay);
 
@@ -93,7 +112,7 @@ contract DualGovernanceConfigTest is UnitTest {
                 config.rageQuitEthWithdrawalsMaxDelay
             )
         );
-        config.validate();
+        this.external__validate(config);
     }
 
     function test_validate_RevertOn_InvalidMinAssetsLockDuration() external {
@@ -102,7 +121,7 @@ contract DualGovernanceConfigTest is UnitTest {
         vm.expectRevert(
             abi.encodeWithSelector(DualGovernanceConfig.InvalidMinAssetsLockDuration.selector, Durations.ZERO)
         );
-        _dualGovernanceConfig.validate();
+        this.external__validate(_dualGovernanceConfig);
     }
 
     // ---
@@ -335,22 +354,20 @@ contract DualGovernanceConfigTest is UnitTest {
         DualGovernanceConfig.Context memory config,
         uint16 rageQuitRound
     ) external {
+        _assumeConfigParams(config);
         vm.assume(rageQuitRound > 0);
         vm.assume(rageQuitRound <= _MAX_RAGE_QUIT_ROUND);
 
-        vm.assume(
-            config.rageQuitEthWithdrawalsMinDelay.toSeconds()
-                + config.rageQuitEthWithdrawalsDelayGrowth.toSeconds() * (rageQuitRound + 1) <= MAX_DURATION_VALUE
-        );
-        vm.assume(config.rageQuitEthWithdrawalsMinDelay <= config.rageQuitEthWithdrawalsMaxDelay);
+        uint256 computedRageQuitEthWithdrawalsDelayInSeconds = config.rageQuitEthWithdrawalsMinDelay.toSeconds()
+            + rageQuitRound * config.rageQuitEthWithdrawalsDelayGrowth.toSeconds();
 
-        Duration computedRageQuitEthWithdrawalsMinDelay = config.rageQuitEthWithdrawalsMinDelay.plusSeconds(
-            rageQuitRound * config.rageQuitEthWithdrawalsDelayGrowth.toSeconds()
-        );
-        if (computedRageQuitEthWithdrawalsMinDelay > config.rageQuitEthWithdrawalsMaxDelay) {
-            computedRageQuitEthWithdrawalsMinDelay = config.rageQuitEthWithdrawalsMaxDelay;
+        if (computedRageQuitEthWithdrawalsDelayInSeconds > config.rageQuitEthWithdrawalsMaxDelay.toSeconds()) {
+            computedRageQuitEthWithdrawalsDelayInSeconds = config.rageQuitEthWithdrawalsMaxDelay.toSeconds();
         }
-        assertEq(config.calcRageQuitWithdrawalsDelay(rageQuitRound), computedRageQuitEthWithdrawalsMinDelay);
+        assertEq(
+            config.calcRageQuitWithdrawalsDelay(rageQuitRound),
+            Durations.from(computedRageQuitEthWithdrawalsDelayInSeconds)
+        );
     }
 
     // ---
@@ -360,8 +377,12 @@ contract DualGovernanceConfigTest is UnitTest {
     function _assumeConfigParams(DualGovernanceConfig.Context memory config) internal view {
         vm.assume(config.firstSealRageQuitSupport < config.secondSealRageQuitSupport);
         vm.assume(config.vetoSignallingMinDuration < config.vetoSignallingMaxDuration);
-        vm.assume(config.secondSealRageQuitSupport < _SECOND_SEAL_RAGE_QUIT_SUPPORT_LIMIT);
+        vm.assume(config.secondSealRageQuitSupport <= _MAX_SECOND_SEAL_RAGE_QUIT_SUPPORT);
         vm.assume(config.rageQuitEthWithdrawalsMinDelay <= config.rageQuitEthWithdrawalsMaxDelay);
         vm.assume(config.minAssetsLockDuration > Durations.ZERO);
+    }
+
+    function external__validate(DualGovernanceConfig.Context memory config) external {
+        config.validate();
     }
 }

--- a/test/unit/libraries/DualGovernanceConfig.t.sol
+++ b/test/unit/libraries/DualGovernanceConfig.t.sol
@@ -11,8 +11,6 @@ import {UnitTest} from "test/utils/unit-test.sol";
 contract DualGovernanceConfigTest is UnitTest {
     using DualGovernanceConfig for DualGovernanceConfig.Context;
 
-    // Unrealistically huge value for the percents value, to limit max fuzz value to avoid overflow
-    // due to very high values
     PercentD16 internal immutable _MAX_SECOND_SEAL_RAGE_QUIT_SUPPORT =
         PercentsD16.from(DualGovernanceConfig.MAX_SECOND_SEAL_RAGE_QUIT_SUPPORT);
     Timestamp internal immutable _MAX_TIMESTAMP = Timestamps.from(block.timestamp + 100 * 365 days);
@@ -337,7 +335,7 @@ contract DualGovernanceConfigTest is UnitTest {
         assertEq(config.calcRageQuitWithdrawalsDelay({rageQuitRound: 0}), config.rageQuitEthWithdrawalsMinDelay);
     }
 
-    function test_calcRageQuitWithdrawalsDelay_HappyPath_MaxDelayWhenRageQuitRoundIsZero() external {
+    function test_calcRageQuitWithdrawalsDelay_HappyPath_MaxDelayWhenRageQuitRoundIsMaxRageQuitRound() external {
         DualGovernanceConfig.Context memory config;
 
         config.rageQuitEthWithdrawalsMinDelay = Durations.from(15 days);
@@ -355,7 +353,6 @@ contract DualGovernanceConfigTest is UnitTest {
         uint16 rageQuitRound
     ) external {
         _assumeConfigParams(config);
-        vm.assume(rageQuitRound > 0);
         vm.assume(rageQuitRound <= _MAX_RAGE_QUIT_ROUND);
 
         uint256 computedRageQuitEthWithdrawalsDelayInSeconds = config.rageQuitEthWithdrawalsMinDelay.toSeconds()

--- a/test/unit/types/Duration.t.sol
+++ b/test/unit/types/Duration.t.sol
@@ -296,10 +296,6 @@ contract DurationTests is UnitTest {
         this.external__from(durationInSeconds);
     }
 
-    function testFuzz_min_HappyPath(Duration d1, Duration d2) external {
-        assertEq(Durations.min(d1, d2), Durations.from(Math.min(d1.toSeconds(), d2.toSeconds())));
-    }
-
     // ---
     // Helper test methods
     // ---


### PR DESCRIPTION
This PR introduces the following changes:
- Added a check to the `validate()` method to ensure that the `secondSealRageQuitSupport` parameter does not exceed 100%.
- Updated `calcRageQuitWithdrawalsDelay()` method to prevent reverts caused by invalid configuration values.