### PR TITLE
Check `minExecutionDelay` in the `canExecute()`

### DIFF
--- a/contracts/EmergencyProtectedTimelock.sol
+++ b/contracts/EmergencyProtectedTimelock.sol
@@ -18,8 +18,9 @@ import {EmergencyProtection} from "./libraries/EmergencyProtection.sol";
 ///     a compromised or misbehaving (including those caused by code vulnerabilities) governance entity.
 /// @dev The proposal lifecycle:
 ///
-///                                         afterSubmitDelay          afterScheduleDelay
-///                                              passed                     passed
+///                                                                MIN_EXECUTION_DELAY and
+///                                         afterSubmitDelay         afterScheduleDelay
+///                                              passed                    passed
 ///     ┌──────────┐            ┌───────────┐              ┌───────────┐             ╔══════════╗
 ///     │ NotExist ├ submit() ─>│ Submitted ├ schedule() ─>│ Scheduled ├ execute() ─>║ Executed ║
 ///     └──────────┘            └────────┬──┘              └──┬────────┘             ╚══════════╝

--- a/contracts/EmergencyProtectedTimelock.sol
+++ b/contracts/EmergencyProtectedTimelock.sol
@@ -377,7 +377,7 @@ contract EmergencyProtectedTimelock is IEmergencyProtectedTimelock {
     /// @return A boolean indicating if the proposal can be executed.
     function canExecute(uint256 proposalId) external view returns (bool) {
         return !_emergencyProtection.isEmergencyModeActive()
-            && _proposals.canExecute(proposalId, _timelockState.getAfterScheduleDelay());
+            && _proposals.canExecute(proposalId, _timelockState.getAfterScheduleDelay(), MIN_EXECUTION_DELAY);
     }
 
     /// @notice Checks if a proposal can be scheduled.

--- a/contracts/libraries/ExecutableProposals.sol
+++ b/contracts/libraries/ExecutableProposals.sol
@@ -215,19 +215,24 @@ library ExecutableProposals {
             && Timestamps.now() >= afterSubmitDelay.addTo(proposalData.submittedAt);
     }
 
-    /// @notice Determines whether a proposal is eligible for execution based on its status and delay requirements.
+    /// @notice Determines whether a proposal is eligible for execution based on its status and delays requirements.
     /// @param self The context of the Executable Proposal library.
     /// @param proposalId The id of the proposal to check for execution eligibility.
     /// @param afterScheduleDelay The required delay duration after scheduling before the proposal can be executed.
+    /// @param minExecutionDelay The required minimum delay after submission before execution is allowed.
     /// @return bool `true` if the proposal is eligible for execution, otherwise `false`.
     function canExecute(
         Context storage self,
         uint256 proposalId,
-        Duration afterScheduleDelay
+        Duration afterScheduleDelay,
+        Duration minExecutionDelay
     ) internal view returns (bool) {
+        Timestamp currentTime = Timestamps.now();
         ProposalData memory proposalData = self.proposals[proposalId].data;
+
         return proposalId > self.lastCancelledProposalId && proposalData.status == Status.Scheduled
-            && Timestamps.now() >= afterScheduleDelay.addTo(proposalData.scheduledAt);
+            && currentTime >= afterScheduleDelay.addTo(proposalData.scheduledAt)
+            && currentTime >= minExecutionDelay.addTo(proposalData.submittedAt);
     }
 
     /// @notice Returns the total count of submitted proposals.

--- a/test/unit/libraries/ExecutableProposals.t.sol
+++ b/test/unit/libraries/ExecutableProposals.t.sol
@@ -448,10 +448,10 @@ contract ExecutableProposalsUnitTests is UnitTest {
         uint256 proposalId = _proposals.getProposalsCount();
         _proposals.schedule(proposalId, Durations.ZERO);
 
-        assert(_proposals.canExecute(proposalId, Durations.ZERO, Durations.ZERO));
+        assertTrue(_proposals.canExecute(proposalId, Durations.ZERO, Durations.ZERO));
         _proposals.cancelAll();
 
-        assert(!_proposals.canExecute(proposalId, Durations.ZERO, Durations.ZERO));
+        assertFalse(_proposals.canExecute(proposalId, Durations.ZERO, Durations.ZERO));
     }
 
     function test_cancelAll_DoesNotModifyStateOfExecutedProposals() external {


### PR DESCRIPTION
This PR updates the `ExecutableProposals.canExecute()` method to account for possible `minExecutionDelay` constraint violations. Without this change, in extraordinary cases, `canExecute()` may return an incorrect result.