### PR TITLE
Correct NatSpec inaccuracies

### DIFF
--- a/contracts/DualGovernance.sol
+++ b/contracts/DualGovernance.sol
@@ -237,7 +237,7 @@ contract DualGovernance is IDualGovernance {
 
         if (!_stateMachine.canCancelAllPendingProposals({useEffectiveState: false})) {
             /// @dev Some proposer contracts, like Aragon Voting, may not support canceling decisions that have already
-            ///     reached consensus. This could lead to a situation where a proposer’s cancelAllPendingProposals() call
+            ///     reached consensus. This could lead to a situation where a cancelAllPendingProposals() call
             ///     becomes unexecutable if the Dual Governance state changes. However, it might become executable again if
             ///     the system state shifts back to VetoSignalling or VetoSignallingDeactivation.
             ///     To avoid such a scenario, an early return is used instead of a revert when proposals cannot be cancelled
@@ -252,7 +252,7 @@ contract DualGovernance is IDualGovernance {
     }
 
     /// @notice Returns whether proposal submission is allowed based on the current `effective` state of the Dual Governance system.
-    /// @dev Proposal submission is forbidden in the `VetoSignalling` and `VetoSignallingDeactivation` states.
+    /// @dev Proposal submission is forbidden in the `VetoCooldown` and `VetoSignallingDeactivation` states.
     /// @return canSubmitProposal A boolean value indicating whether proposal submission is allowed (`true`) or not (`false`)
     ///     based on the current `effective` state of the Dual Governance system.
     function canSubmitProposal() external view returns (bool) {
@@ -263,8 +263,8 @@ contract DualGovernance is IDualGovernance {
     ///     state of the Dual Governance system, the proposal's submission time, and its current status.
     /// @dev Proposal scheduling is allowed only if all the following conditions are met:
     ///     - The Dual Governance system is in the `Normal` or `VetoCooldown` state.
-    ///     - If the system is in the `VetoCooldown` state, the proposal must have been submitted before the system
-    ///         last entered the `VetoSignalling` state.
+    ///     - If the system is in the `VetoCooldown` state, the proposal must have been submitted no later than
+    ///         when the system last entered the `VetoSignalling` state.
     ///     - The proposal has not already been scheduled, cancelled, or executed.
     ///     - The required delay period, as defined by `ITimelock.getAfterSubmitDelay()`, has elapsed since the proposal
     ///         was submitted.

--- a/contracts/EmergencyProtectedTimelock.sol
+++ b/contracts/EmergencyProtectedTimelock.sol
@@ -272,7 +272,7 @@ contract EmergencyProtectedTimelock is IEmergencyProtectedTimelock {
     }
 
     /// @notice Returns whether the emergency mode is active.
-    /// @return isEmergencyModeActive A boolean indicating whether the emergency protection is enabled.
+    /// @return isEmergencyModeActive A boolean indicating whether the emergency mode is active.
     function isEmergencyModeActive() external view returns (bool) {
         return _emergencyProtection.isEmergencyModeActive();
     }
@@ -346,16 +346,16 @@ contract EmergencyProtectedTimelock is IEmergencyProtectedTimelock {
     /// @param proposalId The id of the proposal to return information for.
     /// @return proposalDetails A ProposalDetails struct containing the details of the proposal, with the following data:
     ///     - `id`: The id of the proposal.
+    ///     - `executor`: The address of the executor responsible for executing the proposal's external calls.
+    ///     - `submittedAt`: The timestamp when the proposal was submitted.
+    ///     - `scheduledAt`: The timestamp when the proposal was scheduled for execution. Equals 0 if the proposal
+    ///            was submitted but not yet scheduled.
     ///     - `status`: The current status of the proposal. Possible values are:
     ///         1 - The proposal was submitted but not scheduled.
     ///         2 - The proposal was submitted and scheduled but not yet executed.
     ///         3 - The proposal was submitted, scheduled, and executed. This is the final state of the proposal lifecycle.
     ///         4 - The proposal was cancelled via cancelAllNonExecutedProposals() and cannot be scheduled or executed anymore.
     ///             This is the final state of the proposal.
-    ///     - `executor`: The address of the executor responsible for executing the proposal's external calls.
-    ///     - `submittedAt`: The timestamp when the proposal was submitted.
-    ///     - `scheduledAt`: The timestamp when the proposal was scheduled for execution. Equals 0 if the proposal
-    ///            was submitted but not yet scheduled.
     function getProposalDetails(uint256 proposalId) external view returns (ProposalDetails memory proposalDetails) {
         return _proposals.getProposalDetails(proposalId);
     }

--- a/contracts/Escrow.sol
+++ b/contracts/Escrow.sol
@@ -458,7 +458,7 @@ contract Escrow is ISignallingEscrow, IRageQuitEscrow {
     ///     the first unclaimed unstETH NFT.
     /// @param fromUnstETHId The id of the first unclaimed unstETH NFT in the batch to be claimed.
     /// @param hints An array of hints required by the `WithdrawalQueue` contract to efficiently process
-    ///     the claiming of unstETH NFTs.
+    ///     the claiming of unstETH NFTs. Passing an empty array will cause the method to revert with an index OOB error.
     function claimNextWithdrawalsBatch(uint256 fromUnstETHId, uint256[] calldata hints) external {
         _escrowState.checkRageQuitEscrow();
         _escrowState.checkBatchesClaimingInProgress();
@@ -471,7 +471,8 @@ contract Escrow is ISignallingEscrow, IRageQuitEscrow {
     /// @notice An overloaded version of `Escrow.claimNextWithdrawalsBatch(uint256, uint256[] calldata)` that calculates
     ///     hints for the WithdrawalQueue on-chain. This method provides a more convenient claiming process but is
     ///     less gas efficient compared to `Escrow.claimNextWithdrawalsBatch(uint256, uint256[] calldata)`.
-    /// @param maxUnstETHIdsCount The maximum number of unstETH NFTs to claim in this batch.
+    /// @param maxUnstETHIdsCount The maximum number of unstETH NFTs to claim in this batch. Passing zero will cause
+    ///     the method to revert with an index OOB error.
     function claimNextWithdrawalsBatch(uint256 maxUnstETHIdsCount) external {
         _escrowState.checkRageQuitEscrow();
         _escrowState.checkBatchesClaimingInProgress();

--- a/contracts/Escrow.sol
+++ b/contracts/Escrow.sol
@@ -367,8 +367,8 @@ contract Escrow is ISignallingEscrow, IRageQuitEscrow {
 
     /// @notice Returns the total amounts of locked and claimed assets in the Escrow.
     /// @return details A struct containing the total amounts of locked and claimed assets, including:
-    ///     - `totalStETHClaimedETH`: The total amount of ETH claimed from locked stETH.
     ///     - `totalStETHLockedShares`: The total number of stETH shares currently locked in the Escrow.
+    ///     - `totalStETHClaimedETH`: The total amount of ETH claimed from locked stETH.
     ///     - `totalUnstETHUnfinalizedShares`: The total number of shares from unstETH NFTs that have not yet been finalized.
     ///     - `totalUnstETHFinalizedETH`: The total amount of ETH from finalized unstETH NFTs.
     function getSignallingEscrowDetails() external view returns (SignallingEscrowDetails memory details) {
@@ -605,10 +605,10 @@ contract Escrow is ISignallingEscrow, IRageQuitEscrow {
 
     /// @notice Returns details about the current state of the rage quit escrow.
     /// @return details A `RageQuitEscrowDetails` struct containing the following fields:
-    /// - `isRageQuitExtensionPeriodStarted`: Indicates whether the rage quit extension period has started.
     /// - `rageQuitEthWithdrawalsDelay`: The delay period for ETH withdrawals during rage quit.
     /// - `rageQuitExtensionPeriodDuration`: The duration of the rage quit extension period.
     /// - `rageQuitExtensionPeriodStartedAt`: The timestamp when the rage quit extension period started.
+    /// - `isRageQuitExtensionPeriodStarted`: Indicates whether the rage quit extension period has started.
     function getRageQuitEscrowDetails() external view returns (RageQuitEscrowDetails memory details) {
         _escrowState.checkRageQuitEscrow();
 

--- a/contracts/ImmutableDualGovernanceConfigProvider.sol
+++ b/contracts/ImmutableDualGovernanceConfigProvider.sol
@@ -20,7 +20,7 @@ contract ImmutableDualGovernanceConfigProvider is IDualGovernanceConfigProvider 
     // ---
 
     /// @notice The percentage of the total stETH supply that must be reached in the Signalling Escrow to transition
-    ///     Dual Governance from the Normal state to the VetoSignalling state.
+    ///     Dual Governance from the Normal, VetoCooldown and RageQuit state to the VetoSignalling state.
     PercentD16 public immutable FIRST_SEAL_RAGE_QUIT_SUPPORT;
 
     /// @notice The percentage of the total stETH supply that must be reached in the Signalling Escrow to transition

--- a/contracts/ResealManager.sol
+++ b/contracts/ResealManager.sol
@@ -43,7 +43,6 @@ contract ResealManager is IResealManager {
     /// @dev Works only if conditions are met:
     /// - ResealManager has PAUSE_ROLE and RESUME_ROLE for target contract;
     /// - Contract are paused until timestamp after current timestamp and not for infinite time;
-    /// - The DAO governance is blocked by DualGovernance;
     /// - Function is called by the governance contract.
     /// @param sealable The address of the sealable contract.
     function reseal(address sealable) external {

--- a/contracts/libraries/AssetsAccounting.sol
+++ b/contracts/libraries/AssetsAccounting.sol
@@ -33,7 +33,7 @@ struct HolderAssets {
 struct UnstETHAccounting {
     /// @dev slot0: [0..127]
     SharesValue unfinalizedShares;
-    /// @dev slot1: [128..255]
+    /// @dev slot0: [128..255]
     ETHValue finalizedETH;
 }
 
@@ -64,7 +64,7 @@ enum UnstETHRecordStatus {
 
 /// @notice Stores information about an accounted unstETH NFT.
 /// @param status The current status of the unstETH NFT. Refer to `UnstETHRecordStatus` for details.
-/// @param index The one-based index of the unstETH NFT in the `UnstETHAccounting.unstETHIds` array.
+/// @param index The one-based index of the unstETH NFT in the `HolderAssets.unstETHIds` array.
 /// @param lockedBy The address of the account that locked the unstETH.
 /// @param shares The number of shares contained in the unstETH.
 /// @param claimableAmount The amount of claimable ETH contained in the unstETH. This value is 0

--- a/contracts/libraries/DualGovernanceStateMachine.sol
+++ b/contracts/libraries/DualGovernanceStateMachine.sol
@@ -137,8 +137,8 @@ library DualGovernanceStateMachine {
     /// @notice Executes a state transition for the Dual Governance State Machine, if applicable.
     ///     If no transition is possible from the current `persisted` state, no changes are applied to the context.
     /// @dev If the state transitions to RageQuit, a new instance of the Signalling Escrow is deployed using
-    ///     `escrowMasterCopy` as the implementation for the minimal proxy, while the previous Signalling Escrow
-    ///     instance is converted into the RageQuit escrow.
+    ///     `signallingEscrow.ESCROW_MASTER_COPY()` as the implementation for the minimal proxy,
+    ///     while the previous Signalling Escrow instance is converted into the RageQuit escrow.
     /// @param self The context of the Dual Governance State Machine.
     function activateNextState(Context storage self) internal {
         DualGovernanceConfig.Context memory config = getDualGovernanceConfig(self);

--- a/contracts/libraries/EmergencyProtection.sol
+++ b/contracts/libraries/EmergencyProtection.sol
@@ -55,13 +55,13 @@ library EmergencyProtection {
         Timestamp emergencyModeEndsAfter;
         /// @dev slot0 [40..199]
         address emergencyActivationCommittee;
-        /// @dev slot0 [200..240]
+        /// @dev slot0 [200..239]
         Timestamp emergencyProtectionEndsAfter;
         /// @dev slot1 [0..159]
         address emergencyExecutionCommittee;
         /// @dev slot1 [160..191]
         Duration emergencyModeDuration;
-        /// @dev slot2 [0..160]
+        /// @dev slot2 [0..159]
         address emergencyGovernance;
     }
 
@@ -226,9 +226,9 @@ library EmergencyProtection {
         return self.emergencyModeEndsAfter.isNotZero();
     }
 
-    /// @notice Checks if the emergency mode has passed.
+    /// @notice Checks if the emergency mode duration has passed.
     /// @param self The context of the Emergency Protection library
-    /// @return bool Whether the emergency mode has passed or not.
+    /// @return bool Whether the emergency mode duration has passed or not.
     function isEmergencyModeDurationPassed(Context storage self) internal view returns (bool) {
         Timestamp endsAfter = self.emergencyModeEndsAfter;
         return endsAfter.isNotZero() && Timestamps.now() > endsAfter;

--- a/contracts/libraries/EscrowState.sol
+++ b/contracts/libraries/EscrowState.sol
@@ -12,7 +12,7 @@ import {Timestamp, Timestamps} from "../types/Timestamp.sol";
 /// @param SignallingEscrow In this state, the Escrow contract functions as an on-chain oracle for measuring stakers' disagreement
 ///     with DAO decisions. Users are allowed to lock and unlock funds in the Escrow contract in this state.
 /// @param RageQuitEscrow The final state of the Escrow contract. In this state, the Escrow instance acts as an accumulator
-///     for withdrawn funds locked during the VetoSignalling phase.
+///     for withdrawn funds locked during the SignallingEscrow state.
 enum State {
     NotInitialized,
     SignallingEscrow,
@@ -52,6 +52,9 @@ library EscrowState {
     /// @param rageQuitExtensionPeriodDuration The period of time that starts after all withdrawal batches are formed,
     ///     which delays the exit from the RageQuit state of the DualGovernance. The main purpose of the rage quit
     ///     extension period is to provide enough time for users who locked their unstETH to claim it.
+    /// @param rageQuitExtensionPeriodStartedAt The timestamp when the rage quit extension period started.
+    /// @param rageQuitEthWithdrawalsDelay The waiting period after the Rage Quit process is finalized before vetoers
+    ///     can withdraw ETH from the Escrow.
     struct Context {
         /// @dev slot0: [0..7]
         State state;
@@ -167,14 +170,14 @@ library EscrowState {
     // Getters
     // ---
 
-    /// @notice Returns whether if the rage quit extension period has started.
+    /// @notice Returns whether the rage quit extension period has started.
     /// @param self The context of the Escrow State library.
     /// @return bool `true` if the rage quit extension period has started, `false` otherwise.
     function isRageQuitExtensionPeriodStarted(Context storage self) internal view returns (bool) {
         return self.rageQuitExtensionPeriodStartedAt.isNotZero();
     }
 
-    /// @notice Returns whether if the rage quit extension period has passed.
+    /// @notice Returns whether the rage quit extension period has passed.
     /// @param self The context of the Escrow State library.
     /// @return bool `true` if the rage quit extension period has passed, `false` otherwise.
     function isRageQuitExtensionPeriodPassed(Context storage self) internal view returns (bool) {

--- a/contracts/libraries/ExecutableProposals.sol
+++ b/contracts/libraries/ExecutableProposals.sol
@@ -17,12 +17,12 @@ import {ExternalCall, ExternalCalls, IExternalExecutor} from "./ExternalCalls.so
 ///     reachable from Submitted.
 /// @param Executed Proposal has been successfully executed after being scheduled. This state is
 ///     only reachable from Scheduled and is the final state of the proposal.
-/// @param Cancelled Proposal was cancelled before execution. Cancelled proposals cannot be resubmitted
-///     or rescheduled. This state is only reachable from Submitted or Scheduled and is the final state
+/// @param Cancelled Proposal was cancelled before execution. Cancelled proposals cannot be scheduled
+///     or executed. This state is only reachable from Submitted or Scheduled and is the final state
 ///     of the proposal.
 ///     @dev A proposal is considered cancelled if it was not executed and its id is less than
 ///         the id of the last submitted proposal at the time the `cancelAll()` method was called.
-///         To check if a proposal is in the `Cancelled` state, use the `_isProposalMarkedCancelled()`
+///         To check if a proposal is in the `Cancelled` state, use the `_isProposalCancelled()`
 ///         view function.
 enum Status {
     NotExist,
@@ -245,8 +245,8 @@ library ExecutableProposals {
     /// @notice Retrieves detailed information about a specific previously submitted proposal.
     /// @param self The context of the Executable Proposal library.
     /// @param proposalId The id of the proposal to retrieve details for.
-    /// @return proposalDetails A struct containing the proposal’s id, status, executor, submission timestamp,
-    ///     and scheduling timestamp, if applicable
+    /// @return proposalDetails A struct containing the proposal’s id, executor, submission timestamp,
+    ///      scheduling timestamp and status, if applicable
     function getProposalDetails(
         Context storage self,
         uint256 proposalId

--- a/contracts/libraries/Tiebreaker.sol
+++ b/contracts/libraries/Tiebreaker.sol
@@ -223,7 +223,8 @@ library Tiebreaker {
     /// @dev Retrieves the tiebreaker context from the storage.
     /// @param self The context of the Tiebreaker library.
     /// @param stateDetails A struct containing detailed information about the current state of the Dual Governance system
-    /// @return context The tiebreaker context containing the tiebreaker committee, tiebreaker activation timeout, and sealable withdrawal blockers.
+    /// @return context The tiebreaker context, including whether a tie exists, the tiebreaker committee, tiebreaker activation timeout,
+    ///     and sealable withdrawal blockers.
     function getTiebreakerDetails(
         Context storage self,
         IDualGovernance.StateDetails memory stateDetails

--- a/contracts/libraries/TimelockState.sol
+++ b/contracts/libraries/TimelockState.sol
@@ -37,7 +37,7 @@ library TimelockState {
         address governance;
         /// @dev slot0 [160..191]
         Duration afterSubmitDelay;
-        /// @dev slot0 [192..224]
+        /// @dev slot0 [192..223]
         Duration afterScheduleDelay;
         /// @dev slot1 [0..159]
         address adminExecutor;
@@ -91,11 +91,11 @@ library TimelockState {
         self.afterScheduleDelay = newAfterScheduleDelay;
         emit AfterScheduleDelaySet(newAfterScheduleDelay);
     }
+
     /// @notice Sets the admin executor address.
     /// @dev Reverts if the new admin executor address is zero or the same as the current one.
     /// @param self The context of the timelock state.
     /// @param newAdminExecutor The new admin executor address.
-
     function setAdminExecutor(Context storage self, address newAdminExecutor) internal {
         if (newAdminExecutor == address(0) || newAdminExecutor == self.adminExecutor) {
             revert InvalidAdminExecutor(newAdminExecutor);

--- a/contracts/libraries/WithdrawalsBatchesQueue.sol
+++ b/contracts/libraries/WithdrawalsBatchesQueue.sol
@@ -51,12 +51,12 @@ library WithdrawalsBatchesQueue {
     }
 
     /// @notice Holds the meta-information about the queue and the claiming process.
-    /// @param state The current state of the WithdrawalQueue library.
+    /// @param state The current state of the WithdrawalsBatchesQueue library.
     /// @param lastClaimedBatchIndex The index of the batch containing the id of the last claimed unstETH NFT.
     /// @param lastClaimedUnstETHIdIndex The index of the last claimed unstETH id in the batch with
     ///     index `lastClaimedBatchIndex`.
-    /// @param totalUnstETHCount The total number of unstETH ids in all batches.
-    /// @param totalUnstETHClaimed The total number of unstETH ids that have been marked as claimed.
+    /// @param totalUnstETHIdsCount The total number of unstETH ids in all batches.
+    /// @param totalUnstETHIdsClaimed The total number of unstETH ids that have been marked as claimed.
     struct QueueInfo {
         /// @dev slot0: [0..7]
         State state;


### PR DESCRIPTION
This PR **ONLY** modifies comments across the contracts and libraries to correct inaccuracies in the NatSpec documentation. 

These changes do not affect the resulting bytecode of the compiled contracts, except for the CBOR-encoded [metadata hash of the contract](https://docs.soliditylang.org/en/latest/metadata.html).