### PR TITLE
Set forge dependencies

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -32,3 +32,7 @@ multiline_func_header = 'params_first_multi'
 mainnet = { key = "${ETHERSCAN_API_KEY}" }
 holesky = { key = "${ETHERSCAN_API_KEY}", chain = "17000" }
 hoodi = { key = "${ETHERSCAN_API_KEY}", chain = "560048", url = "https://api-hoodi.etherscan.io/api" }
+
+[dependencies]
+openzeppelin-contracts = "5.0.2"
+forge-std = "1.9.3"


### PR DESCRIPTION
This PR adds [Soldeer-compatible](https://getfoundry.sh/guides/project-setup/soldeer/) dependency versions to foundry.toml while keeping existing git submodules as the source of truth. The actual dependency code still comes from pinned commits in lib/ directory, but the version specifications (openzeppelin-contracts@5.0.2, forge-std@1.9.3) provide better tooling integration and soldeer support.