### PR TITLE
Prevent repeated calls to Escrow.startRageQuitExtensionPeriod()

### DIFF
--- a/contracts/libraries/EscrowState.sol
+++ b/contracts/libraries/EscrowState.sol
@@ -106,7 +106,7 @@ library EscrowState {
     /// @notice Starts the rage quit extension period.
     /// @param self The context of the Escrow State library.
     function startRageQuitExtensionPeriod(Context storage self) internal {
-        if (self.rageQuitExtensionPeriodStartedAt != Timestamps.ZERO) {
+        if (self.rageQuitExtensionPeriodStartedAt.isNotZero()) {
             revert RageQuitExtensionPeriodAlreadyStarted();
         }
         self.rageQuitExtensionPeriodStartedAt = Timestamps.now();

--- a/contracts/libraries/EscrowState.sol
+++ b/contracts/libraries/EscrowState.sol
@@ -31,6 +31,7 @@ library EscrowState {
     error EthWithdrawalsDelayNotPassed();
     error RageQuitExtensionPeriodNotStarted();
     error InvalidMinAssetsLockDuration(Duration newMinAssetsLockDuration);
+    error RageQuitExtensionPeriodAlreadyStarted();
 
     // ---
     // Events
@@ -105,6 +106,9 @@ library EscrowState {
     /// @notice Starts the rage quit extension period.
     /// @param self The context of the Escrow State library.
     function startRageQuitExtensionPeriod(Context storage self) internal {
+        if (self.rageQuitExtensionPeriodStartedAt != Timestamps.ZERO) {
+            revert RageQuitExtensionPeriodAlreadyStarted();
+        }
         self.rageQuitExtensionPeriodStartedAt = Timestamps.now();
         emit RageQuitExtensionPeriodStarted(self.rageQuitExtensionPeriodStartedAt);
     }

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -1301,6 +1301,7 @@ Initiates the `RageQuitExtensionPeriod` once all withdrawal batches have been cl
 - All withdrawal batches MUST be formed using the `Escrow.requestNextWithdrawalsBatch`.
 - The last unstETH NFT in the `WithdrawalQueue` at the time of the `Escrow.startRageQuit` call MUST be finalized.
 - All withdrawal batches generated during `Escrow.requestNextWithdrawalsBatch` MUST be claimed.
+- The `RageQuitExtensionPeriod` MUST NOT have already been started.
 
 ---
 

--- a/test/unit/Escrow.t.sol
+++ b/test/unit/Escrow.t.sol
@@ -1096,6 +1096,21 @@ contract EscrowUnitTests is UnitTest {
         _escrow.startRageQuitExtensionPeriod();
     }
 
+    function test_startRageQuitExtensionPeriod_RevertOn_RepeatedCalls() external {
+        _transitToRageQuit();
+
+        _ensureWithdrawalsBatchesQueueClosed();
+
+        assertEq(_escrow.getRageQuitEscrowDetails().rageQuitExtensionPeriodStartedAt, Timestamps.ZERO);
+
+        _ensureRageQuitExtensionPeriodStartedNow();
+
+        assertEq(_escrow.getRageQuitEscrowDetails().rageQuitExtensionPeriodStartedAt, Timestamps.now());
+
+        vm.expectRevert(abi.encodeWithSelector(EscrowStateLib.RageQuitExtensionPeriodAlreadyStarted.selector));
+        _escrow.startRageQuitExtensionPeriod();
+    }
+
     // ---
     // claimUnstETH()
     // ---


### PR DESCRIPTION
This change ensures that `Escrow.startRageQuitExtensionPeriod()` can be invoked only once.